### PR TITLE
[codex] fix sync skip flags

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -156,6 +156,16 @@ func TestAppRejectsUnknownCommand(t *testing.T) {
 	}
 }
 
+func TestParseSyncOptionsKeepsSkipFlags(t *testing.T) {
+	opts := parseSyncOptions([]string{"--source", "desktop-cache", "--limit", "2", "--no-transcripts", "--no-panels"})
+	if opts.Source != model.SourceDesktopCache || opts.Limit != 2 {
+		t.Fatalf("bad source or limit: %#v", opts)
+	}
+	if !opts.SkipTranscripts || !opts.SkipPanels {
+		t.Fatalf("expected skip flags, got %#v", opts)
+	}
+}
+
 func writeTestConfig(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -17,8 +17,8 @@ func parseSyncOptions(args []string) syncer.Options {
 			opts.Limit = n
 		}
 	}
-	opts.IncludeTranscripts = !hasFlag(args, "--no-transcripts")
-	opts.IncludePanels = !hasFlag(args, "--no-panels")
+	opts.SkipTranscripts = hasFlag(args, "--no-transcripts")
+	opts.SkipPanels = hasFlag(args, "--no-panels")
 	return opts
 }
 

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -16,8 +16,8 @@ func Run(ctx context.Context, cfg config.Config, st *store.Store, opts Options) 
 	if opts.Limit == 0 {
 		opts.Limit = cfg.Sync.DefaultLimit
 	}
-	opts.IncludeTranscripts = opts.IncludeTranscripts || cfg.Sync.IncludeTranscripts
-	opts.IncludePanels = opts.IncludePanels || cfg.Sync.IncludePanels
+	opts.IncludeTranscripts = !opts.SkipTranscripts && (opts.IncludeTranscripts || cfg.Sync.IncludeTranscripts)
+	opts.IncludePanels = !opts.SkipPanels && (opts.IncludePanels || cfg.Sync.IncludePanels)
 	switch opts.Source {
 	case model.SourcePrivateAPI:
 		if !cfg.Granola.AllowPrivateAPI {

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -1,0 +1,57 @@
+package syncer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vincentkoc/graincrawl/internal/config"
+	"github.com/vincentkoc/graincrawl/internal/model"
+	"github.com/vincentkoc/graincrawl/internal/store"
+)
+
+func TestRunHonorsSkipTranscriptsForDesktopCache(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{"cache":{"version":6,"state":{"documents":{"doc1":{"id":"doc1","created_at":"2026-05-06T01:00:00Z","updated_at":"2026-05-06T02:00:00Z","title":"Test","type":"meeting","notes_plain":"plain"}},"transcripts":{"doc1":[{"document_id":"doc1","start_timestamp":"2026-05-06T01:00:01Z","end_timestamp":"2026-05-06T01:00:02Z","text":"hello","source":"microphone","id":"c1","is_final":true}]}}}}`
+	if err := os.WriteFile(filepath.Join(profile, "cache-v6.json"), []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:       profile,
+			AllowDesktopCache: true,
+		},
+		Sync: config.SyncConfig{
+			DefaultLimit:       100,
+			IncludeTranscripts: true,
+		},
+	}
+	result, err := Run(ctx, cfg, st, Options{
+		Source:          model.SourceDesktopCache,
+		SkipTranscripts: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Notes != 1 || result.Transcripts != 0 {
+		t.Fatalf("expected one note and no transcripts, got %#v", result)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Notes != 1 || status.Transcripts != 0 {
+		t.Fatalf("expected archived note without transcript, got %#v", status)
+	}
+}

--- a/internal/syncer/types.go
+++ b/internal/syncer/types.go
@@ -7,6 +7,8 @@ type Options struct {
 	Limit              int          `json:"limit"`
 	IncludeTranscripts bool         `json:"include_transcripts"`
 	IncludePanels      bool         `json:"include_panels"`
+	SkipTranscripts    bool         `json:"-"`
+	SkipPanels         bool         `json:"-"`
 }
 
 type Result struct {


### PR DESCRIPTION
## Summary

Fixes sync option handling so CLI opt-out flags such as `--no-transcripts` and `--no-panels` are preserved when sync defaults are applied.

## Root cause

`parseSyncOptions` previously encoded `--no-transcripts` by setting `IncludeTranscripts` to false, but `syncer.Run` later ORed that value with config defaults. When the config default enabled transcripts, the explicit CLI opt-out was overwritten.

## Changes

- Add explicit skip fields to sync options for transcripts and panels.
- Apply config defaults only when the corresponding skip flag is not set.
- Add CLI parser coverage for both skip flags.
- Add a desktop-cache regression test proving `SkipTranscripts` prevents transcript archival even when config defaults enable transcripts.

## Validation

- `make test`
- Manual desktop-cache bulk test with 48 synthetic notes and 144 transcript chunks
- Confirmed `sync --source desktop-cache --no-transcripts --no-panels` reports `transcripts: 0` after the fix
