### PR TITLE
build(deps): bump crawlkit to v0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/pelletier/go-toml/v2 v2.3.0
-	github.com/vincentkoc/crawlkit v0.4.0
+	github.com/vincentkoc/crawlkit v0.4.1
 	modernc.org/sqlite v1.50.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/vincentkoc/crawlkit v0.4.0 h1:1jQZAYbBivy6d7ewNdMZ8THgmJVwb+pQT0kH5Z9COHI=
-github.com/vincentkoc/crawlkit v0.4.0/go.mod h1:/ioLA/tyZ/927kAOGg0M8Mrqk7pnTZLpCKWfpul9zoE=
+github.com/vincentkoc/crawlkit v0.4.1 h1:qDUF+Kk7nqADmpGMcnWTHEQMiX3bSD2DdFywKyT3kWs=
+github.com/vincentkoc/crawlkit v0.4.1/go.mod h1:/ioLA/tyZ/927kAOGg0M8Mrqk7pnTZLpCKWfpul9zoE=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -25,6 +25,9 @@ func (a App) Run(ctx context.Context, args []string) error {
 		stdout = io.Discard
 	}
 	flags, rest := parseGlobalFlags(args)
+	if flags.Version {
+		return a.runVersion(stdout, flags)
+	}
 	if flags.Help || len(rest) == 0 {
 		_, err := io.WriteString(stdout, usage)
 		return err

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -57,6 +57,17 @@ func TestAppStatusAndSecurityCommandsUseTempConfig(t *testing.T) {
 	}
 }
 
+func TestAppGlobalVersionFlag(t *testing.T) {
+	var out bytes.Buffer
+	app := App{Stdout: &out}
+	if err := app.Run(context.Background(), []string{"--version"}); err != nil {
+		t.Fatalf("--version failed: %v", err)
+	}
+	if !strings.Contains(out.String(), "version") {
+		t.Fatalf("--version output missing version: %s", out.String())
+	}
+}
+
 func TestAppSnapshotExportImportUseTempArchive(t *testing.T) {
 	cfgPath := writeTestConfig(t)
 	snapshotDir := filepath.Join(t.TempDir(), "snapshot")

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -6,6 +6,7 @@ type GlobalFlags struct {
 	ConfigPath string
 	JSON       bool
 	Help       bool
+	Version    bool
 }
 
 func parseGlobalFlags(args []string) (GlobalFlags, []string) {
@@ -18,6 +19,8 @@ func parseGlobalFlags(args []string) (GlobalFlags, []string) {
 			flags.JSON = true
 		case "--help", "-h":
 			flags.Help = true
+		case "--version", "-v":
+			flags.Version = true
 		case "--config":
 			if i+1 < len(args) {
 				flags.ConfigPath = args[i+1]

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -3,7 +3,7 @@ package cli
 const usage = `graincrawl archives Granola notes locally.
 
 Usage:
-  graincrawl [--json] [--config <path>] <command> [args]
+  graincrawl [--json] [--config <path>] [--version] <command> [args]
 
 Commands:
   version                 Show build metadata.


### PR DESCRIPTION
## Summary
- bump `github.com/vincentkoc/crawlkit` to `v0.4.1`
- add the global `--version`/`-v` alias so graincrawl matches the other crawl CLIs

## Validation
- `GOWORK=off go test ./...`
- local binary rebuilt into `~/.local/bin`
- temp-dir smoke: `--help`, `--version`, `metadata --json`, `status --json`, `tui --json`