### PR TITLE
Fix invalid Go version directive in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/graincrawl
 
-go 1.26.3
+go 1.26
 
 require (
 	github.com/openclaw/crawlkit v0.9.0


### PR DESCRIPTION
This PR fixes an invalid go directive in go.mod that prevents users from installing graincrawl with go install.

### Problem

The module currently declares:

`go 1.26.3`

But the go directive only accepts major.minor format, so patch versions are rejected by the Go toolchain.

This causes installs like the following to fail:

`go install github.com/openclaw/graincrawl/cmd/graincrawl@latest`

with:

`invalid go version '1.26.3': must match format 1.23`

### Fix

Changed:

`go 1.26.3`

to:

`go 1.26`

If patch-level toolchain pinning is desired, that should be represented with a separate toolchain directive instead.

### Result

go install github.com/openclaw/graincrawl/cmd/graincrawl@latest should work again for users with a compatible Go toolchain.