### PR TITLE
ci: add deadcode check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,13 @@ jobs:
         run: GOWORK=off go install golang.org/x/tools/cmd/deadcode@v0.45.0
 
       - name: Deadcode
-        run: GOWORK=off "$(go env GOPATH)/bin/deadcode" -test ./...
+        run: |
+          output_file=$(mktemp)
+          GOWORK=off "$(go env GOPATH)/bin/deadcode" -test ./... > "$output_file"
+          if [ -s "$output_file" ]; then
+            cat "$output_file"
+            exit 1
+          fi
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,12 @@ jobs:
       - name: Vet
         run: GOWORK=off go vet ./...
 
+      - name: Install deadcode
+        run: GOWORK=off go install golang.org/x/tools/cmd/deadcode@v0.45.0
+
+      - name: Deadcode
+        run: GOWORK=off "$(go env GOPATH)/bin/deadcode" -test ./...
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/internal/cli/control.go
+++ b/internal/cli/control.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openclaw/crawlkit/control"
 	"github.com/openclaw/graincrawl/internal/config"
 	"github.com/openclaw/graincrawl/internal/output"
-	gruntime "github.com/openclaw/graincrawl/internal/runtime"
 	"github.com/openclaw/graincrawl/internal/store"
 )
 
@@ -100,17 +99,4 @@ func fileSize(path string) int64 {
 		return 0
 	}
 	return info.Size()
-}
-
-func openRuntimeStatus(ctx context.Context, configPath string) (gruntime.Runtime, store.Status, error) {
-	rt, err := gruntime.Open(ctx, configPath)
-	if err != nil {
-		return gruntime.Runtime{}, store.Status{}, err
-	}
-	status, err := rt.Store.Status(ctx)
-	if err != nil {
-		_ = rt.Close()
-		return gruntime.Runtime{}, store.Status{}, err
-	}
-	return rt, status, nil
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -29,14 +29,6 @@ func WriteEnvelope(w io.Writer, value any) error {
 	return WriteJSON(w, Envelope{OK: true, Result: value})
 }
 
-func WriteError(w io.Writer, err error) error {
-	msg := ""
-	if err != nil {
-		msg = err.Error()
-	}
-	return WriteJSON(w, Envelope{OK: false, Error: msg})
-}
-
 func PrintKV(w io.Writer, key string, value any) {
 	fmt.Fprintf(w, "%s: %v\n", key, value)
 }

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -27,10 +27,3 @@ func Key(key string) bool {
 	}
 	return false
 }
-
-func String(value string) string {
-	if value == "" {
-		return ""
-	}
-	return Mask
-}


### PR DESCRIPTION
## Summary
- add an enforced Go deadcode CI gate pinned to `golang.org/x/tools/cmd/deadcode@v0.45.0`
- remove unreachable helpers reported by deadcode
- make the workflow fail when deadcode emits findings

## Validation
- `git diff --check`
- `GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go build ./cmd/graincrawl`
- `autoreview --mode branch --base origin/main --no-web-search --thinking low` clean
