### PR TITLE
fix: report encrypted Granola state diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add a clear diagnostic when Granola desktop exposes encrypted-only state, thanks @elijahmuraoka.
+
 ## v0.2.1 - 2026-05-18
 
 - Accept plaintext Granola cache version 8 for desktop-cache sync, including

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -112,6 +112,9 @@ func (a App) runSync(ctx context.Context, w io.Writer, flags GlobalFlags, args [
 	output.PrintKV(w, "notes", result.Notes)
 	output.PrintKV(w, "transcripts", result.Transcripts)
 	output.PrintKV(w, "panels", result.Panels)
+	if result.Message != "" {
+		output.PrintKV(w, "message", result.Message)
+	}
 	return nil
 }
 
@@ -179,6 +182,9 @@ func (a App) runDoctor(ctx context.Context, w io.Writer, flags GlobalFlags) erro
 	output.PrintKV(w, "granola_version", report.GranolaApp.Version)
 	output.PrintKV(w, "cache_v6", report.Files.CacheV6.Exists)
 	output.PrintKV(w, "supabase", report.Files.Supabase.Exists)
+	for _, diagnostic := range report.Diagnostics {
+		output.PrintKV(w, "diagnostic", diagnostic.Message)
+	}
 	output.PrintKV(w, "opfs_present", report.Unlock.OPFSPresent)
 	output.PrintKV(w, "keychain_may_prompt", report.Unlock.KeychainMayPrompt)
 	return nil

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -74,6 +75,55 @@ func TestAppGlobalVersionFlag(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "version") {
 		t.Fatalf("--version output missing version: %s", out.String())
+	}
+}
+
+func TestAppReportsEncryptedOnlyGranolaState(t *testing.T) {
+	cfgPath := writeTestConfig(t)
+	cfg, _, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cfg.Granola.ProfilePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cacheRaw := `{"cache":{"version":8,"state":{"transcripts":{}}}}`
+	if err := os.WriteFile(filepath.Join(cfg.Granola.ProfilePath, "cache-v6.json"), []byte(cacheRaw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"supabase.json.enc", "storage.dek"} {
+		if err := os.WriteFile(filepath.Join(cfg.Granola.ProfilePath, name), []byte("encrypted"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, command := range [][]string{
+		{"--json", "--config", cfgPath, "doctor"},
+		{"--config", cfgPath, "doctor"},
+		{"--json", "--config", cfgPath, "sync"},
+		{"--json", "--config", cfgPath, "sync", "--source", "desktop-cache"},
+		{"--config", cfgPath, "sync", "--source", "desktop-cache"},
+	} {
+		var out bytes.Buffer
+		app := App{Stdout: &out}
+		if err := app.Run(context.Background(), command); err != nil {
+			t.Fatalf("%v failed: %v", command, err)
+		}
+		text := out.String()
+		for _, want := range []string{"encrypted-only", "not implemented", "supabase.json"} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("%v output missing %q:\n%s", command, want, text)
+			}
+		}
+	}
+
+	var unlockOut bytes.Buffer
+	app := App{Stdout: &unlockOut}
+	if err := app.Run(context.Background(), []string{"--json", "--config", cfgPath, "unlock"}); err != nil {
+		t.Fatalf("unlock failed: %v", err)
+	}
+	if !strings.Contains(unlockOut.String(), "not implemented") {
+		t.Fatalf("unlock output should not imply implemented encrypted unlock:\n%s", unlockOut.String())
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -9,13 +9,14 @@ import (
 )
 
 type Report struct {
-	ConfigPath string                `json:"config_path"`
-	DBPath     string                `json:"db_path"`
-	GranolaApp granola.AppInfo       `json:"granola_app"`
-	Profile    granola.ProfilePaths  `json:"profile"`
-	Files      FileReport            `json:"files"`
-	Token      *granola.TokenSummary `json:"token,omitempty"`
-	Unlock     UnlockReport          `json:"unlock"`
+	ConfigPath  string                `json:"config_path"`
+	DBPath      string                `json:"db_path"`
+	GranolaApp  granola.AppInfo       `json:"granola_app"`
+	Profile     granola.ProfilePaths  `json:"profile"`
+	Files       FileReport            `json:"files"`
+	Token       *granola.TokenSummary `json:"token,omitempty"`
+	Unlock      UnlockReport          `json:"unlock"`
+	Diagnostics []Diagnostic          `json:"diagnostics,omitempty"`
 }
 
 type FileReport struct {
@@ -33,6 +34,12 @@ type UnlockReport struct {
 	EncryptedJSONRequired bool `json:"encrypted_json_required"`
 	OPFSPresent           bool `json:"opfs_present"`
 	KeychainMayPrompt     bool `json:"keychain_may_prompt"`
+}
+
+type Diagnostic struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
 }
 
 func Run(cfg config.Config, configPath string, now time.Time) Report {
@@ -59,7 +66,14 @@ func Run(cfg config.Config, configPath string, now time.Time) Report {
 	}
 	report.Unlock.EncryptedJSONRequired = granola.EncryptedNewer(paths.CacheV6, paths.CacheV6Encrypted) || granola.EncryptedNewer(paths.Supabase, paths.SupabaseEncrypted)
 	report.Unlock.OPFSPresent = report.Files.IndexedDB.Exists && report.Files.FileSystem.Exists
-	report.Unlock.KeychainMayPrompt = report.Unlock.EncryptedJSONRequired || cfg.Granola.AllowEncryptedJSON || cfg.Granola.AllowOPFS
+	report.Unlock.KeychainMayPrompt = false
+	if granola.EncryptedOnlyState(paths) {
+		report.Diagnostics = append(report.Diagnostics, Diagnostic{
+			Code:     "granola_encrypted_only_state",
+			Severity: "warning",
+			Message:  granola.EncryptedOnlyStateMessage,
+		})
+	}
 	return report
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,76 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/graincrawl/internal/config"
+	"github.com/openclaw/graincrawl/internal/granola"
+)
+
+func TestRunReportsEncryptedOnlyGranolaState(t *testing.T) {
+	profile := filepath.Join(t.TempDir(), "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"supabase.json.enc", "cache-v6.json.enc", "storage.dek"} {
+		if err := os.WriteFile(filepath.Join(profile, name), []byte("encrypted"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	report := Run(config.Config{
+		Granola: config.GranolaConfig{ProfilePath: profile},
+	}, "/tmp/graincrawl.toml", time.Now())
+	if !report.Unlock.EncryptedJSONRequired {
+		t.Fatal("expected encrypted JSON to be required")
+	}
+	if report.Unlock.KeychainMayPrompt {
+		t.Fatal("diagnostic-only encrypted state must not imply a keychain prompt")
+	}
+	if len(report.Diagnostics) != 1 {
+		t.Fatalf("expected one diagnostic, got %#v", report.Diagnostics)
+	}
+	diagnostic := report.Diagnostics[0]
+	if diagnostic.Code != "granola_encrypted_only_state" || diagnostic.Severity != "warning" {
+		t.Fatalf("unexpected diagnostic metadata: %#v", diagnostic)
+	}
+	if !strings.Contains(diagnostic.Message, "encrypted-only") ||
+		!strings.Contains(diagnostic.Message, "not implemented") ||
+		!strings.Contains(diagnostic.Message, "supabase.json") {
+		t.Fatalf("diagnostic does not explain encrypted-only state: %q", diagnostic.Message)
+	}
+	if diagnostic.Message != granola.EncryptedOnlyStateMessage {
+		t.Fatalf("doctor should use shared message, got %q", diagnostic.Message)
+	}
+}
+
+func TestRunReportsEncryptedOnlyCacheState(t *testing.T) {
+	profile := filepath.Join(t.TempDir(), "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "cache-v6.json.enc"), []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "storage.dek"), []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	supabaseRaw := `{"workos_tokens":"{\"access_token\":\"token\",\"obtained_at\":4102444800000,\"expires_in\":3600}"}`
+	if err := os.WriteFile(filepath.Join(profile, "supabase.json"), []byte(supabaseRaw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report := Run(config.Config{
+		Granola: config.GranolaConfig{ProfilePath: profile},
+	}, "/tmp/graincrawl.toml", time.Now())
+	if len(report.Diagnostics) != 1 {
+		t.Fatalf("expected encrypted-cache diagnostic, got %#v", report.Diagnostics)
+	}
+	if !strings.Contains(report.Diagnostics[0].Message, "cache-v6.json") {
+		t.Fatalf("diagnostic should mention plaintext cache, got %q", report.Diagnostics[0].Message)
+	}
+}

--- a/internal/granola/files.go
+++ b/internal/granola/files.go
@@ -2,6 +2,8 @@ package granola
 
 import "os"
 
+const EncryptedOnlyStateMessage = "Granola desktop state is encrypted-only; encrypted-json unlock/import is not implemented in this version; re-signing into Granola desktop will not fix this unless it emits plaintext supabase.json/cache-v6.json."
+
 type FileState struct {
 	Path    string `json:"path"`
 	Exists  bool   `json:"exists"`
@@ -31,4 +33,16 @@ func EncryptedNewer(plain, encrypted string) bool {
 		return true
 	}
 	return e.ModTime().After(p.ModTime())
+}
+
+func EncryptedOnlyState(paths ProfilePaths) bool {
+	return EncryptedCacheState(paths) || EncryptedSupabaseState(paths)
+}
+
+func EncryptedCacheState(paths ProfilePaths) bool {
+	return EncryptedNewer(paths.CacheV6, paths.CacheV6Encrypted)
+}
+
+func EncryptedSupabaseState(paths ProfilePaths) bool {
+	return EncryptedNewer(paths.Supabase, paths.SupabaseEncrypted)
 }

--- a/internal/security/report.go
+++ b/internal/security/report.go
@@ -52,14 +52,14 @@ func Sources(cfg config.Config) []SourceSupport {
 			Allowed:     cfg.Granola.AllowEncryptedJSON,
 			Implemented: false,
 			NeedsSecret: true,
-			Notes:       "requires explicit companion/keychain unlock",
+			Notes:       "unsupported in this build; encrypted-only Granola state requires future explicit unlock/import",
 		},
 		{
 			Source:      model.SourceOPFS,
 			Allowed:     cfg.Granola.AllowOPFS,
 			Implemented: false,
 			NeedsSecret: true,
-			Notes:       "requires explicit companion/keychain unlock",
+			Notes:       "unsupported in this build; future explicit unlock/import must be security reviewed",
 		},
 		{
 			Source:      model.SourcePublicAPI,
@@ -97,10 +97,7 @@ func Secrets(cfg config.Config) SecretReport {
 
 func unlockMessage(needsCompanion bool, mode string) string {
 	if !needsCompanion {
-		return "encrypted JSON and OPFS sources are disabled; no keychain prompt is expected"
+		return "encrypted JSON and OPFS sources are disabled; encrypted-json unlock/import is not implemented in this version, and no keychain prompt is expected"
 	}
-	if mode == "ask" || mode == "always" {
-		return "encrypted sources are enabled and may trigger an explicit keychain prompt through a companion helper"
-	}
-	return "encrypted sources are enabled but keychain prompting is disabled until keychain_prompt_mode is changed"
+	return "encrypted local sources are configured, but encrypted-json/OPFS unlock/import is not implemented in this version; no companion helper or keychain prompt will run"
 }

--- a/internal/syncer/desktop_cache.go
+++ b/internal/syncer/desktop_cache.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/openclaw/graincrawl/internal/cachev6"
@@ -16,8 +17,19 @@ func DesktopCache(ctx context.Context, cfg config.Config, st *store.Store, opts 
 	started := time.Now().UTC()
 	result := Result{Source: source}
 	paths := granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath)
+	encryptedOnlyMessage := ""
+	if granola.EncryptedOnlyState(paths) {
+		encryptedOnlyMessage = granola.EncryptedOnlyStateMessage
+	}
+	if granola.EncryptedCacheState(paths) {
+		result.Message = encryptedOnlyMessage
+		return result, fmt.Errorf("desktop-cache source requires plaintext cache-v6.json: %s", encryptedOnlyMessage)
+	}
 	file, err := cachev6.Read(paths.CacheV6)
 	if err != nil {
+		if encryptedOnlyMessage != "" {
+			return result, fmt.Errorf("%w: %s", err, encryptedOnlyMessage)
+		}
 		return result, err
 	}
 	now := time.Now().UTC()
@@ -57,7 +69,10 @@ func DesktopCache(ctx context.Context, cfg config.Config, st *store.Store, opts 
 			}
 		}
 	}
+	if encryptedOnlyMessage != "" {
+		result.Message = encryptedOnlyMessage
+	}
 	completed := time.Now().UTC()
-	_, _ = st.InsertSyncRun(ctx, model.SyncRun{Source: source, StartedAt: started, CompletedAt: completed, Status: "ok", Notes: result.Notes, Transcripts: result.Transcripts, Panels: result.Panels})
+	_, _ = st.InsertSyncRun(ctx, model.SyncRun{Source: source, StartedAt: started, CompletedAt: completed, Status: "ok", Notes: result.Notes, Transcripts: result.Transcripts, Panels: result.Panels, Message: result.Message})
 	return result, nil
 }

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/openclaw/graincrawl/internal/config"
+	"github.com/openclaw/graincrawl/internal/granola"
 	"github.com/openclaw/graincrawl/internal/model"
 	"github.com/openclaw/graincrawl/internal/store"
 )
@@ -24,6 +25,14 @@ func Run(ctx context.Context, cfg config.Config, st *store.Store, opts Options) 
 	case model.SourcePrivateAPI:
 		if !cfg.Granola.AllowPrivateAPI {
 			return Result{}, fmt.Errorf("private-api source disabled in config")
+		}
+		encryptedSupabase := granola.EncryptedSupabaseState(granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath))
+		if encryptedSupabase && !sourceExplicit && cfg.Granola.AllowDesktopCache {
+			opts.Source = model.SourceDesktopCache
+			return DesktopCache(ctx, cfg, st, opts)
+		}
+		if encryptedSupabase {
+			return Result{Source: model.SourcePrivateAPI, Message: granola.EncryptedOnlyStateMessage}, fmt.Errorf("private-api source requires plaintext supabase.json: %s", granola.EncryptedOnlyStateMessage)
 		}
 		result, err := PrivateAPI(ctx, cfg, st, opts)
 		if err != nil && !sourceExplicit && cfg.Granola.AllowDesktopCache && privateAPIAuthUnavailable(err) {

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/openclaw/graincrawl/internal/config"
 	"github.com/openclaw/graincrawl/internal/model"
@@ -99,6 +101,134 @@ func TestRunAcceptsEmptyVersion8DesktopCache(t *testing.T) {
 	}
 }
 
+func TestRunExplainsEncryptedOnlyDesktopCache(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{"cache":{"version":8,"state":{"transcripts":{}}}}`
+	if err := os.WriteFile(filepath.Join(profile, "cache-v6.json"), []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"supabase.json.enc", "storage.dek"} {
+		if err := os.WriteFile(filepath.Join(profile, name), []byte("encrypted"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:       profile,
+			AllowDesktopCache: true,
+		},
+		Sync: config.SyncConfig{DefaultLimit: 100},
+	}
+	result, err := Run(ctx, cfg, st, Options{Source: model.SourceDesktopCache})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Notes != 0 || !strings.Contains(result.Message, "encrypted-only") {
+		t.Fatalf("expected encrypted-only diagnostic on empty sync, got %#v", result)
+	}
+	runs, err := st.ListSyncRuns(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 || runs[0].Message != result.Message {
+		t.Fatalf("expected diagnostic recorded with sync run, got %#v", runs)
+	}
+}
+
+func TestRunDefaultSyncFallsBackWithEncryptedOnlyDiagnostic(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{"cache":{"version":8,"state":{"documents":{"doc1":{"id":"doc1","created_at":"2026-05-06T01:00:00Z","updated_at":"2026-05-06T02:00:00Z","title":"Cached","type":"meeting","notes_plain":"cached plain"}},"transcripts":{}}}}`
+	if err := os.WriteFile(filepath.Join(profile, "cache-v6.json"), []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	supabasePath := filepath.Join(profile, "supabase.json")
+	supabaseEncPath := filepath.Join(profile, "supabase.json.enc")
+	supabaseRaw := `{"workos_tokens":"{\"access_token\":\"stale\",\"obtained_at\":4102444800000,\"expires_in\":3600}"}`
+	if err := os.WriteFile(supabasePath, []byte(supabaseRaw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"supabase.json.enc", "storage.dek"} {
+		if err := os.WriteFile(filepath.Join(profile, name), []byte("encrypted"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	makeNewer(t, supabasePath, supabaseEncPath)
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:       profile,
+			PreferredSource:   "private-api",
+			AllowPrivateAPI:   true,
+			AllowDesktopCache: true,
+		},
+		Sync: config.SyncConfig{DefaultLimit: 100},
+	}
+	result, err := Run(ctx, cfg, st, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Source != model.SourceDesktopCache || result.Notes != 1 || !strings.Contains(result.Message, "encrypted-only") {
+		t.Fatalf("expected default sync fallback with encrypted-only diagnostic, got %#v", result)
+	}
+}
+
+func TestRunRejectsNewerEncryptedDesktopCache(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(profile, "cache-v6.json")
+	cacheEncPath := filepath.Join(profile, "cache-v6.json.enc")
+	raw := `{"cache":{"version":8,"state":{"documents":{"doc1":{"id":"doc1","created_at":"2026-05-06T01:00:00Z","updated_at":"2026-05-06T02:00:00Z","title":"Cached","type":"meeting","notes_plain":"cached plain"}},"transcripts":{}}}}`
+	if err := os.WriteFile(cachePath, []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cacheEncPath, []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	makeNewer(t, cachePath, cacheEncPath)
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:       profile,
+			AllowDesktopCache: true,
+		},
+		Sync: config.SyncConfig{DefaultLimit: 100},
+	}
+	result, err := Run(ctx, cfg, st, Options{Source: model.SourceDesktopCache})
+	if err == nil {
+		t.Fatalf("expected stale plaintext cache rejection, got %#v", result)
+	}
+	if !strings.Contains(err.Error(), "cache-v6.json") || !strings.Contains(err.Error(), "encrypted-only") {
+		t.Fatalf("expected encrypted-cache diagnostic error, got %v", err)
+	}
+}
+
 func TestRunFallsBackToDesktopCacheForImplicitExpiredPrivateAPI(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
@@ -137,5 +267,17 @@ func TestRunFallsBackToDesktopCacheForImplicitExpiredPrivateAPI(t *testing.T) {
 	}
 	if _, err := Run(ctx, cfg, st, Options{Source: model.SourcePrivateAPI}); !errors.Is(err, ErrPrivateAPITokenExpired) {
 		t.Fatalf("explicit private-api should still fail with token expiry, got %v", err)
+	}
+}
+
+func makeNewer(t *testing.T, olderPath, newerPath string) {
+	t.Helper()
+	older := time.Now().Add(-2 * time.Hour)
+	newer := time.Now().Add(-1 * time.Hour)
+	if err := os.Chtimes(olderPath, older, older); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(newerPath, newer, newer); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary

- add a shared encrypted-only Granola diagnostic for newer or missing plaintext `supabase.json` / `cache-v6.json`
- surface the diagnostic in `doctor`, `sync`, `sources`, and `unlock`
- preflight encrypted Supabase state before private-api sync can use stale plaintext auth
- reject stale plaintext desktop-cache imports when encrypted `cache-v6.json.enc` is newer
- add synthetic temp-profile coverage for diagnostic, fallback, stale-cache, and CLI behavior

Addresses the diagnostic-only part of #15. The full encrypted-json unlock/import implementation remains security-sensitive and should be tracked separately with explicit maintainer approval.

## Verification

- `GOWORK=off go test ./internal/doctor ./internal/security ./internal/syncer ./internal/cli`
- `GOWORK=off go test -race ./...`
- `make check`
- `make smoke`
- `make release-snapshot`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local`

Synthetic encrypted-state proof showed:

```text
doctor: diagnostic code granola_encrypted_only_state, keychain_may_prompt=false
sync: source desktop-cache, notes=1, encrypted-only diagnostic message present
sources: encrypted-json implemented=false, unsupported in this build
unlock: encrypted-json unlock/import is not implemented; no keychain prompt expected
stale desktop-cache: rejects newer cache-v6.json.enc instead of importing stale plaintext
```
