### PR TITLE
feat: add encrypted JSON unlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add explicit in-memory encrypted Granola JSON unlock for cache import and private API authentication.
 - Add a clear diagnostic when Granola desktop exposes encrypted-only state, thanks @elijahmuraoka.
 
 ## v0.2.1 - 2026-05-18

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ browser over the archived SQLite data.
 - export notes to Markdown
 - browse archived notes with the shared crawlkit TUI
 - create/import portable crawlkit snapshots
-- keep encrypted JSON, OPFS, Keychain, and helper paths behind explicit unlock
-  surfaces
+- explicitly unlock encrypted JSON for in-memory cache import or private API
+  authentication; keep OPFS unsupported
 
 ## Install
 
@@ -62,7 +62,9 @@ graincrawl check-update
 graincrawl metadata
 graincrawl status
 graincrawl sync --source private-api
+graincrawl sync --source private-api --unlock encrypted-json
 graincrawl sync --source desktop-cache
+graincrawl sync --source desktop-cache --unlock encrypted-json
 graincrawl runs
 graincrawl notes
 graincrawl search "decision"
@@ -74,6 +76,7 @@ graincrawl people
 graincrawl workspaces
 graincrawl sources
 graincrawl unlock
+graincrawl unlock encrypted-json
 graincrawl secrets
 graincrawl export markdown --out ./granola-notes
 graincrawl snapshot create --out ./graincrawl-snapshot
@@ -114,8 +117,10 @@ See [docs/distribution.md](docs/distribution.md).
 read endpoints or local files and stores its own archive under the configured
 graincrawl paths.
 
-Encrypted JSON, OPFS, Electron safeStorage, and macOS Keychain paths require
-explicit unlock flow. Ordinary `doctor`, `status`, `notes`, `export`, and `tui`
-commands must not surprise-prompt Keychain.
+Encrypted JSON and macOS Keychain access require `allow_encrypted_json = true`
+plus an explicit `unlock encrypted-json` command or `--unlock encrypted-json`
+sync flag. Decrypted payloads stay in process memory and are not written back
+to Granola. OPFS remains unsupported. Ordinary `doctor`, `status`, `notes`,
+`export`, and `tui` commands never prompt Keychain.
 
 See [docs/security.md](docs/security.md).

--- a/SPEC.md
+++ b/SPEC.md
@@ -139,8 +139,8 @@ operator should always know which trust boundary is being crossed.
 - module: `github.com/openclaw/graincrawl`
 - binary: `graincrawl`
 - language: Go for the CLI/archive
-- helper language: minimal Electron/Node helper for macOS local encrypted
-  surfaces
+- encrypted JSON: in-process Go implementation after explicit authorization;
+  future OPFS work may still require Electron
 - shared library: `github.com/openclaw/crawlkit`
 - default local app dir: `~/.config/graincrawl`
 
@@ -185,8 +185,7 @@ Default request headers:
 Token behavior:
 
 - Read `supabase.json` plaintext when available.
-- If `supabase.json.enc` exists and is newer, require explicit unlock through
-  the helper.
+- If `supabase.json.enc` exists and is newer, require explicit unlock.
 - If token is still valid, use it.
 - If token is expired, default behavior is to fail with a clear message:
   `open Granola or run graincrawl unlock --allow-refresh`.
@@ -257,7 +256,7 @@ Encrypted cache behavior:
 
 ### `encrypted-json`
 
-Mac helper source for Electron safeStorage-backed JSON files.
+Explicit macOS unlock source for Electron safeStorage-backed JSON files.
 
 Inputs:
 
@@ -271,33 +270,33 @@ Process:
 1. Operator runs an explicit command:
    - `graincrawl unlock encrypted-json`
    - or `graincrawl sync --source desktop-cache --unlock encrypted-json`
-2. CLI starts a short-lived helper.
-3. Helper sets Electron app name to `Granola`.
-4. Helper calls `safeStorage.decryptString(storage.dek)`.
-5. Helper AES-GCM decrypts requested `.enc` files.
-6. Helper returns parsed JSON or a temp plaintext stream over stdout/pipe.
-7. CLI imports data.
-8. Helper exits.
+2. CLI validates `allow_encrypted_json` and `keychain_prompt_mode`, then
+   snapshots only the requested encrypted files into memory.
+3. CLI reads the `Granola Safe Storage` / `Granola Key` generic password
+   through `/usr/bin/security`.
+4. CLI unwraps the Chromium `v10` safeStorage payload using the macOS
+   PBKDF2/AES-CBC format.
+5. CLI AES-GCM decrypts only the requested `.enc` files.
+6. CLI imports data and clears sensitive byte buffers where practical.
 
 Security rules:
 
-- No long-running helper.
+- No hidden command or alternate Keychain entry point.
 - No raw DEK logs.
 - No raw token logs.
-- No decrypted file written to disk by default.
-- If a temp file is necessary for debugging, require `--debug-keep-temp` and
-  write under a mode `0700` temp dir.
+- No decrypted file written to disk.
 - Keychain prompts must only happen inside explicit unlock commands.
 - CLI output must say which surface triggered Keychain/safeStorage access.
 
 Potential Keychain friction:
 
 - macOS may bind the safeStorage secret to app name/service/account identity.
-- A helper may trigger a prompt that appears to reference Granola.
+- The Keychain lookup may trigger a prompt that references `security` or
+  graincrawl.
 - If access is denied, `graincrawl` should degrade cleanly:
   `encrypted storage locked; rerun with --unlock or use private-api`.
-- If helper identity breaks across Electron versions, fallback to asking the
-  operator to open Granola and use API/companion CLI.
+- If the safeStorage format changes, fallback to asking the operator to open
+  Granola and use API/companion CLI.
 
 ### `opfs`
 
@@ -615,7 +614,7 @@ Desktop cache sync:
 Encrypted JSON sync:
 
 1. Require explicit unlock.
-2. Decrypt target JSON files via helper.
+2. Decrypt target JSON files in memory after authorization.
 3. Reuse desktop cache or supabase token parser.
 
 OPFS sync:
@@ -643,19 +642,18 @@ Conflict behavior:
 - Keep all raw source payloads for audit.
 - Show source disagreements in `doctor data` or `graincrawl note diff <id>`.
 
-## keychain and helper process
+## keychain and unlock process
 
 This is the riskiest part. Make it boring and explicit.
 
-Helper binary:
+Encrypted JSON implementation:
 
-- name: `graincrawl-granola-helper`
-- implementation: small Electron app/script, launched by `graincrawl`
-- lifetime: one command
-- transport: stdout JSON lines or a local pipe
-- timeout: default 30 seconds
-- temp dirs: mode `0700`
-- cleanup: always remove temp profile copies unless `--debug-keep-temp`
+- no hidden command or alternate executable mode
+- runs only after public command authorization checks
+- Keychain timeout: 30 seconds
+- snapshots requested encrypted files into memory before Keychain access
+- clears the Keychain secret, DEK, encrypted snapshot, and decrypted payload
+  buffers where practical
 
 Unlock surfaces:
 
@@ -668,19 +666,18 @@ Rules:
 - `graincrawl status` and ordinary `graincrawl notes` must not trigger
   Keychain prompts.
 - Commands that may prompt must include `unlock` or `--unlock`.
-- Before launching helper, print the surface being accessed unless `--json`.
+- Command output must identify the surface that triggered Keychain access.
 - In JSON mode, report `requires_unlock` instead of prompting unless
   `--unlock` is present.
-- Helper returns only requested data, never the raw safeStorage DEK or OPFS
-  SQLCipher key.
-- Helper stderr is captured and redacted.
-- Helper refuses unknown Granola app versions unless `--allow-unknown-version`.
+- The decryptor returns only requested data, never the raw safeStorage DEK.
+- Raw `/usr/bin/security` stderr is discarded.
+- The decryptor refuses unknown safeStorage prefixes and malformed encrypted
+  payload formats.
 - Helper refuses to read live OPFS directly; it must copy first.
 
 Keychain UX:
 
-- If macOS prompts, the prompt may name Granola or Electron depending on helper
-  identity.
+- If macOS prompts, the prompt may name `security` or graincrawl.
 - Document this in `doctor encrypted-json --explain`.
 - If access is denied, exit non-zero with an actionable message.
 - Do not retry in a loop. One prompt attempt per command.
@@ -784,9 +781,9 @@ only the generic process supervisor/temp-copy/redaction mechanics into
 - add `sync --source desktop-cache`
 - add stale plaintext/encrypted detection
 
-### phase 4: encrypted JSON helper
+### phase 4: encrypted JSON unlock
 
-- add helper scaffold
+- add explicit authorization gate
 - implement safeStorage unwrap
 - implement AES-256-GCM decrypt
 - support decrypting `cache-v6.json.enc` and `supabase.json.enc`
@@ -819,7 +816,7 @@ only the generic process supervisor/temp-copy/redaction mechanics into
 - fixture coverage for API shapes
 - fixture coverage for cache-v6 shape
 - source disagreement reports
-- helper timeout/crash tests
+- Keychain timeout/error tests
 - token redaction tests
 - temp cleanup tests
 - `go test ./...`
@@ -845,7 +842,7 @@ Integration tests:
 
 - private API client with fixture transport
 - desktop cache import from temp fixture
-- encrypted JSON helper with synthetic encrypted payloads
+- encrypted JSON unlock with synthetic encrypted payloads
 - OPFS helper behind a build tag or manual macOS test
 
 Manual proof commands:

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,21 +15,30 @@ already present, plus plaintext cache fallback when Granola still writes one.
 
 That means `graincrawl doctor`, `status`, `notes`, and `export` must not prompt
 macOS Keychain. A Keychain prompt is allowed only after the user explicitly
-enables encrypted sources and changes the prompt mode.
+enables encrypted sources and invokes an explicit unlock command.
 
 ## Keychain Boundary
 
-Encrypted JSON and OPFS support should be implemented through an explicit
-companion/helper process. The helper owns the macOS prompt, returns only the
-minimum unlock material needed for the current operation, and exits. The main
-archive path should avoid keeping helper keys on disk unless
-`persist_helper_keys` is intentionally enabled.
+Encrypted JSON support runs only inside the authorized public command path.
+After configuration and explicit-unlock checks, graincrawl snapshots the
+requested encrypted files into memory, reads the `Granola Safe Storage`
+Keychain item through `/usr/bin/security`, unwraps the DEK, and decrypts only
+the requested JSON. Keychain access has a 30-second timeout. The DEK, Keychain
+secret, and decrypted Granola JSON are never written to disk. There is no
+hidden helper command that can bypass the public authorization checks. OPFS
+remains unsupported.
+
+`allow_encrypted_json = true` permits the feature, but never invokes it by
+itself. The operator must also run `graincrawl unlock encrypted-json` or pass
+`--unlock encrypted-json` to `sync`.
 
 ## Operational Rules
 
 - Do not log tokens, refresh tokens, decrypted keys, cookies, or raw encrypted
   payloads.
 - Do not read or mutate live Granola files in tests.
+- Snapshot encrypted files into memory before Keychain access; never write
+  decrypted Granola JSON to disk.
 - Use temp config, cache, and database paths for tests.
 - Prefer `graincrawl secrets --json` before debugging unlock issues.
 - Prefer `graincrawl unlock --json` before enabling encrypted sources.

--- a/internal/cachev6/read.go
+++ b/internal/cachev6/read.go
@@ -16,6 +16,10 @@ func Read(path string) (File, error) {
 	if err != nil {
 		return File{}, err
 	}
+	return Parse(b)
+}
+
+func Parse(b []byte) (File, error) {
 	var file File
 	if err := json.Unmarshal(b, &file); err != nil {
 		return File{}, err

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -9,14 +9,16 @@ import (
 	"github.com/openclaw/graincrawl/internal/buildinfo"
 	"github.com/openclaw/graincrawl/internal/config"
 	"github.com/openclaw/graincrawl/internal/doctor"
+	"github.com/openclaw/graincrawl/internal/encryptedjson"
 	"github.com/openclaw/graincrawl/internal/output"
 	gruntime "github.com/openclaw/graincrawl/internal/runtime"
 	"github.com/openclaw/graincrawl/internal/syncer"
 )
 
 type App struct {
-	Stdout io.Writer
-	Stderr io.Writer
+	Stdout               io.Writer
+	Stderr               io.Writer
+	DecryptEncryptedJSON encryptedjson.DecryptFunc
 }
 
 func (a App) Run(ctx context.Context, args []string) error {
@@ -72,7 +74,7 @@ func (a App) Run(ctx context.Context, args []string) error {
 	case "sources":
 		return a.runSources(ctx, stdout, flags)
 	case "unlock":
-		return a.runUnlock(ctx, stdout, flags)
+		return a.runUnlock(ctx, stdout, flags, cmdArgs)
 	case "secrets":
 		return a.runSecrets(ctx, stdout, flags)
 	case "export":
@@ -101,7 +103,9 @@ func (a App) runSync(ctx context.Context, w io.Writer, flags GlobalFlags, args [
 		return err
 	}
 	defer rt.Close()
-	result, err := syncer.Run(ctx, rt.Config, rt.Store, parseSyncOptions(args))
+	opts := parseSyncOptions(args)
+	opts.DecryptEncryptedJSON = a.encryptedJSONDecryptor()
+	result, err := syncer.Run(ctx, rt.Config, rt.Store, opts)
 	if err != nil {
 		return err
 	}
@@ -116,6 +120,13 @@ func (a App) runSync(ctx context.Context, w io.Writer, flags GlobalFlags, args [
 		output.PrintKV(w, "message", result.Message)
 	}
 	return nil
+}
+
+func (a App) encryptedJSONDecryptor() encryptedjson.DecryptFunc {
+	if a.DecryptEncryptedJSON != nil {
+		return a.DecryptEncryptedJSON
+	}
+	return encryptedjson.Decrypt
 }
 
 func (a App) runStatus(ctx context.Context, w io.Writer, flags GlobalFlags) error {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -110,7 +110,7 @@ func TestAppReportsEncryptedOnlyGranolaState(t *testing.T) {
 			t.Fatalf("%v failed: %v", command, err)
 		}
 		text := out.String()
-		for _, want := range []string{"encrypted-only", "not implemented", "supabase.json"} {
+		for _, want := range []string{"encrypted-only", "explicit", "supabase.json"} {
 			if !strings.Contains(text, want) {
 				t.Fatalf("%v output missing %q:\n%s", command, want, text)
 			}
@@ -122,8 +122,92 @@ func TestAppReportsEncryptedOnlyGranolaState(t *testing.T) {
 	if err := app.Run(context.Background(), []string{"--json", "--config", cfgPath, "unlock"}); err != nil {
 		t.Fatalf("unlock failed: %v", err)
 	}
-	if !strings.Contains(unlockOut.String(), "not implemented") {
-		t.Fatalf("unlock output should not imply implemented encrypted unlock:\n%s", unlockOut.String())
+	if !strings.Contains(unlockOut.String(), "disabled") || strings.Contains(unlockOut.String(), "keychain_accessed") {
+		t.Fatalf("unlock status should remain prompt-free when disabled:\n%s", unlockOut.String())
+	}
+}
+
+func TestAppExplicitEncryptedJSONUnlockRedactsPayload(t *testing.T) {
+	cfgPath := writeTestConfig(t)
+	cfg, _, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Granola.AllowEncryptedJSON = true
+	cfg.Security.KeychainPromptMode = "explicit"
+	if err := config.Save(cfgPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cfg.Granola.ProfilePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"storage.dek", "cache-v6.json.enc", "supabase.json.enc"} {
+		if err := os.WriteFile(filepath.Join(cfg.Granola.ProfilePath, name), []byte("encrypted"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cacheRaw := json.RawMessage(`{"cache":{"version":8,"state":{"documents":{"doc1":{"id":"doc1","created_at":"2026-05-06T01:00:00Z","updated_at":"2026-05-06T02:00:00Z","title":"Sensitive title","notes_plain":"Sensitive note"}},"transcripts":{}}}}`)
+	supabaseRaw := json.RawMessage(`{"workos_tokens":"{\"access_token\":\"synthetic-secret-token\",\"refresh_token\":\"synthetic-refresh-token\",\"obtained_at\":4102444800000,\"expires_in\":3600}","user_info":"{\"email\":\"private@example.com\"}"}`)
+	decryptCalls := 0
+	app := App{
+		DecryptEncryptedJSON: func(_ context.Context, _ string, names ...string) (map[string]json.RawMessage, error) {
+			decryptCalls++
+			return map[string]json.RawMessage{
+				"cache-v6.json.enc": cacheRaw,
+				"supabase.json.enc": supabaseRaw,
+			}, nil
+		},
+	}
+
+	var doctorOut bytes.Buffer
+	app.Stdout = &doctorOut
+	if err := app.Run(context.Background(), []string{"--json", "--config", cfgPath, "doctor"}); err != nil {
+		t.Fatal(err)
+	}
+	if decryptCalls != 0 {
+		t.Fatal("doctor invoked encrypted-json decryptor")
+	}
+
+	var unlockOut bytes.Buffer
+	app.Stdout = &unlockOut
+	if err := app.Run(context.Background(), []string{"--json", "--config", cfgPath, "unlock", "encrypted-json"}); err != nil {
+		t.Fatal(err)
+	}
+	if decryptCalls != 1 {
+		t.Fatalf("expected one explicit decryptor call, got %d", decryptCalls)
+	}
+	text := unlockOut.String()
+	for _, want := range []string{`"surface": "encrypted-json"`, `"document_count": 1`, `"present": true`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("unlock output missing %q:\n%s", want, text)
+		}
+	}
+	for _, forbidden := range []string{"synthetic-secret-token", "synthetic-refresh-token", "Sensitive title", "Sensitive note", "private@example.com"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("unlock output leaked %q:\n%s", forbidden, text)
+		}
+	}
+}
+
+func TestAppFormerEncryptedJSONHelperCommandCannotDecrypt(t *testing.T) {
+	decryptCalls := 0
+	var out bytes.Buffer
+	app := App{
+		Stdout: &out,
+		DecryptEncryptedJSON: func(context.Context, string, ...string) (map[string]json.RawMessage, error) {
+			decryptCalls++
+			return nil, nil
+		},
+	}
+	err := app.Run(context.Background(), []string{"_encrypted-json-helper"})
+	if err == nil || !strings.Contains(err.Error(), "unknown command") {
+		t.Fatalf("expected former helper command rejection, got %v", err)
+	}
+	if decryptCalls != 0 {
+		t.Fatalf("former helper command invoked decryptor %d times", decryptCalls)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("former helper command wrote output: %q", out.String())
 	}
 }
 
@@ -268,12 +352,28 @@ func TestAppRejectsUnknownCommand(t *testing.T) {
 }
 
 func TestParseSyncOptionsKeepsSkipFlags(t *testing.T) {
-	opts := parseSyncOptions([]string{"--source", "desktop-cache", "--limit", "2", "--no-transcripts", "--no-panels"})
+	opts := parseSyncOptions([]string{"--source", "desktop-cache", "--limit", "2", "--unlock", "encrypted-json", "--no-transcripts", "--no-panels"})
 	if opts.Source != model.SourceDesktopCache || opts.Limit != 2 {
 		t.Fatalf("bad source or limit: %#v", opts)
 	}
+	if opts.UnlockSurface != "encrypted-json" {
+		t.Fatalf("unlock surface = %q", opts.UnlockSurface)
+	}
 	if !opts.SkipTranscripts || !opts.SkipPanels {
 		t.Fatalf("expected skip flags, got %#v", opts)
+	}
+}
+
+func TestShellCompletionsIncludeEncryptedJSONUnlock(t *testing.T) {
+	for shell, completion := range map[string]string{
+		"bash": bashCompletion(),
+		"zsh":  zshCompletion(),
+	} {
+		for _, want := range []string{"--unlock", "encrypted-json"} {
+			if !strings.Contains(completion, want) {
+				t.Fatalf("%s completion missing %q", shell, want)
+			}
+		}
 	}
 }
 

--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -48,11 +48,15 @@ _graincrawl_completions()
   prev="${COMP_WORDS[COMP_CWORD-1]}"
   commands="%s"
   global_flags="--json --config --help -h"
-  sources="private-api desktop-cache public-api companion-cli encrypted-json opfs"
+  sources="private-api desktop-cache public-api companion-cli opfs"
 
   case "${prev}" in
     --source)
       COMPREPLY=( $(compgen -W "${sources}" -- "${cur}") )
+      return 0
+      ;;
+    --unlock)
+      COMPREPLY=( $(compgen -W "encrypted-json" -- "${cur}") )
       return 0
       ;;
     completion)
@@ -66,7 +70,7 @@ _graincrawl_completions()
     return 0
   fi
 
-  COMPREPLY=( $(compgen -W "${global_flags} --source --limit --out --no-transcripts --no-panels" -- "${cur}") )
+  COMPREPLY=( $(compgen -W "${global_flags} --source --limit --unlock --out --no-transcripts --no-panels" -- "${cur}") )
 }
 complete -F _graincrawl_completions graincrawl
 `, commands)
@@ -91,7 +95,7 @@ _graincrawl() {
     args)
       case $words[2] in
         sync|refresh)
-          _arguments '--source[source adapter]:(private-api desktop-cache public-api companion-cli encrypted-json opfs)' '--limit[limit]:limit:' '--no-transcripts[skip transcripts]' '--no-panels[skip panels]'
+          _arguments '--source[source adapter]:(private-api desktop-cache public-api companion-cli opfs)' '--limit[limit]:limit:' '--unlock[explicit unlock surface]:(encrypted-json)' '--no-transcripts[skip transcripts]' '--no-panels[skip panels]'
           ;;
         export|snapshot)
           _arguments '--out[output directory]:directory:_files -/'

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -24,7 +24,7 @@ Commands:
   people                  List retained people source objects.
   workspaces              List retained workspace source objects.
   sources                 Show source adapter support.
-  unlock                  Explain explicit unlock surfaces.
+  unlock [surface]        Inspect or explicitly unlock a local source.
   secrets                 Inspect graincrawl-managed secret state.
   export markdown         Export notes as Markdown.
   snapshot create         Create a portable crawlkit snapshot.
@@ -35,7 +35,9 @@ Commands:
 Examples:
   graincrawl doctor --json
   graincrawl sync --source private-api
+  graincrawl sync --source private-api --unlock encrypted-json
   graincrawl sync --source desktop-cache
+  graincrawl unlock encrypted-json
   graincrawl notes --json
   graincrawl sql "select count(*) as notes from notes"
 `

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -17,6 +17,9 @@ func parseSyncOptions(args []string) syncer.Options {
 			opts.Limit = n
 		}
 	}
+	if surface, ok := flagValue(args, "--unlock"); ok {
+		opts.UnlockSurface = surface
+	}
 	opts.SkipTranscripts = hasFlag(args, "--no-transcripts")
 	opts.SkipPanels = hasFlag(args, "--no-panels")
 	return opts

--- a/internal/cli/security.go
+++ b/internal/cli/security.go
@@ -2,8 +2,15 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"os"
+	"time"
 
+	"github.com/openclaw/graincrawl/internal/cachev6"
+	"github.com/openclaw/graincrawl/internal/config"
+	"github.com/openclaw/graincrawl/internal/encryptedjson"
+	"github.com/openclaw/graincrawl/internal/granola"
 	"github.com/openclaw/graincrawl/internal/output"
 	gruntime "github.com/openclaw/graincrawl/internal/runtime"
 	"github.com/openclaw/graincrawl/internal/security"
@@ -25,12 +32,26 @@ func (a App) runSources(ctx context.Context, w io.Writer, flags GlobalFlags) err
 	return nil
 }
 
-func (a App) runUnlock(ctx context.Context, w io.Writer, flags GlobalFlags) error {
+type encryptedJSONUnlockResult struct {
+	Surface          string                `json:"surface"`
+	KeychainAccessed bool                  `json:"keychain_accessed"`
+	Files            []string              `json:"files"`
+	Cache            *cachev6.Summary      `json:"cache,omitempty"`
+	Token            *granola.TokenSummary `json:"token,omitempty"`
+}
+
+func (a App) runUnlock(ctx context.Context, w io.Writer, flags GlobalFlags, args []string) error {
 	rt, err := gruntime.Open(ctx, flags.ConfigPath)
 	if err != nil {
 		return err
 	}
 	defer rt.Close()
+	if len(args) > 0 {
+		if len(args) != 1 || args[0] != "encrypted-json" {
+			return fmt.Errorf("unsupported unlock surface %q", args[0])
+		}
+		return a.runEncryptedJSONUnlock(ctx, w, flags, rt.Config)
+	}
 	report := security.Unlock(rt.Config)
 	if flags.JSON {
 		return output.WriteEnvelope(w, report)
@@ -39,6 +60,70 @@ func (a App) runUnlock(ctx context.Context, w io.Writer, flags GlobalFlags) erro
 	output.PrintKV(w, "prompt_allowed", report.PromptAllowed)
 	output.PrintKV(w, "requires_companion", report.RequiresCompanion)
 	output.PrintKV(w, "message", report.Message)
+	return nil
+}
+
+func (a App) runEncryptedJSONUnlock(ctx context.Context, w io.Writer, flags GlobalFlags, cfg config.Config) error {
+	if !cfg.Granola.AllowEncryptedJSON {
+		return fmt.Errorf("encrypted-json source disabled in config")
+	}
+	if !security.PromptAllowed(cfg.Security.KeychainPromptMode) {
+		return fmt.Errorf("keychain prompt mode %q blocks encrypted-json unlock", cfg.Security.KeychainPromptMode)
+	}
+	paths := granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath)
+	names := make([]string, 0, 2)
+	if _, err := os.Stat(paths.CacheV6Encrypted); err == nil {
+		names = append(names, encryptedjson.CacheFile)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect encrypted cache: %w", err)
+	}
+	if _, err := os.Stat(paths.SupabaseEncrypted); err == nil {
+		names = append(names, encryptedjson.SupabaseFile)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("inspect encrypted auth state: %w", err)
+	}
+	if len(names) == 0 {
+		return fmt.Errorf("no encrypted Granola JSON files found")
+	}
+	files, err := a.encryptedJSONDecryptor()(ctx, paths.Root, names...)
+	if err != nil {
+		return err
+	}
+	defer encryptedjson.Clear(files)
+	result := encryptedJSONUnlockResult{
+		Surface:          "encrypted-json",
+		KeychainAccessed: true,
+		Files:            names,
+	}
+	if raw, ok := files[encryptedjson.CacheFile]; ok {
+		file, err := cachev6.Parse(raw)
+		if err != nil {
+			return fmt.Errorf("parse decrypted cache: %w", err)
+		}
+		summary := cachev6.Summarize(file)
+		result.Cache = &summary
+	}
+	if raw, ok := files[encryptedjson.SupabaseFile]; ok {
+		_, tokens, _, err := granola.ParseSupabase(raw)
+		if err != nil {
+			return fmt.Errorf("parse decrypted auth state: %w", err)
+		}
+		summary := granola.SummarizeToken(tokens, time.Now())
+		result.Token = &summary
+	}
+	if flags.JSON {
+		return output.WriteEnvelope(w, result)
+	}
+	output.PrintKV(w, "surface", result.Surface)
+	output.PrintKV(w, "keychain_accessed", result.KeychainAccessed)
+	if result.Cache != nil {
+		output.PrintKV(w, "cache_version", result.Cache.Version)
+		output.PrintKV(w, "cache_documents", result.Cache.DocumentCount)
+	}
+	if result.Token != nil {
+		output.PrintKV(w, "token_present", result.Token.Present)
+		output.PrintKV(w, "token_expired", result.Token.Expired)
+	}
 	return nil
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -39,7 +39,7 @@ func TestRunReportsEncryptedOnlyGranolaState(t *testing.T) {
 		t.Fatalf("unexpected diagnostic metadata: %#v", diagnostic)
 	}
 	if !strings.Contains(diagnostic.Message, "encrypted-only") ||
-		!strings.Contains(diagnostic.Message, "not implemented") ||
+		!strings.Contains(diagnostic.Message, "explicit") ||
 		!strings.Contains(diagnostic.Message, "supabase.json") {
 		t.Fatalf("diagnostic does not explain encrypted-only state: %q", diagnostic.Message)
 	}

--- a/internal/encryptedjson/encryptedjson.go
+++ b/internal/encryptedjson/encryptedjson.go
@@ -1,0 +1,298 @@
+package encryptedjson
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+const (
+	CacheFile    = "cache-v6.json.enc"
+	SupabaseFile = "supabase.json.enc"
+
+	keychainService = "Granola Safe Storage"
+	keychainAccount = "Granola Key"
+	maxFileBytes    = 64 << 20
+	unlockTimeout   = 30 * time.Second
+)
+
+var allowedFiles = map[string]bool{
+	CacheFile:    true,
+	SupabaseFile: true,
+}
+
+type DecryptFunc func(context.Context, string, ...string) (map[string]json.RawMessage, error)
+
+type snapshotData struct {
+	StorageDEK []byte
+	Files      map[string][]byte
+}
+
+func Decrypt(ctx context.Context, profile string, names ...string) (map[string]json.RawMessage, error) {
+	if runtime.GOOS != "darwin" {
+		return nil, errors.New("encrypted-json unlock is supported only on macOS")
+	}
+	snapshot, err := snapshot(profile, names)
+	if err != nil {
+		return nil, err
+	}
+	defer snapshot.clear()
+	unlockCtx, cancel := context.WithTimeout(ctx, unlockTimeout)
+	defer cancel()
+	files, err := decryptSnapshot(unlockCtx, snapshot, readKeychainSecret)
+	if errors.Is(unlockCtx.Err(), context.DeadlineExceeded) {
+		return nil, errors.New("encrypted storage unlock timed out waiting for Keychain access")
+	}
+	if err != nil {
+		return nil, err
+	}
+	for _, name := range names {
+		if _, ok := files[name]; !ok {
+			Clear(files)
+			return nil, errors.New("encrypted storage decryptor omitted a requested file")
+		}
+	}
+	return files, nil
+}
+
+func decryptSnapshot(ctx context.Context, snapshot snapshotData, keychain func(context.Context) ([]byte, error)) (map[string]json.RawMessage, error) {
+	secret, err := keychain(ctx)
+	if err != nil {
+		return nil, errors.New("encrypted storage unlock failed; Keychain access may have been denied")
+	}
+	defer zero(secret)
+	dek, err := unwrapDEK(secret, snapshot.StorageDEK)
+	if err != nil {
+		return nil, errors.New("encrypted storage could not be decrypted with the current Granola Keychain item")
+	}
+	defer zero(dek)
+	files := make(map[string]json.RawMessage, len(snapshot.Files))
+	for name, encrypted := range snapshot.Files {
+		plain, err := decryptJSON(dek, encrypted)
+		if err != nil {
+			Clear(files)
+			return nil, errors.New("encrypted storage could not be decrypted with the current Granola Keychain item")
+		}
+		files[name] = plain
+	}
+	return files, nil
+}
+
+func Clear(files map[string]json.RawMessage) {
+	for name, data := range files {
+		zero(data)
+		delete(files, name)
+	}
+}
+
+func (snapshot snapshotData) clear() {
+	zero(snapshot.StorageDEK)
+	for name, data := range snapshot.Files {
+		zero(data)
+		delete(snapshot.Files, name)
+	}
+}
+
+func snapshot(profile string, names []string) (snapshotData, error) {
+	if len(names) == 0 {
+		return snapshotData{}, errors.New("no encrypted JSON files requested")
+	}
+	result := snapshotData{Files: make(map[string][]byte, len(names))}
+	var err error
+	result.StorageDEK, err = readStableRegularFile(filepath.Join(profile, "storage.dek"))
+	if err != nil {
+		return snapshotData{}, fmt.Errorf("read storage.dek: %w", err)
+	}
+	for _, name := range names {
+		if !allowedFiles[name] {
+			result.clear()
+			return snapshotData{}, fmt.Errorf("unsupported encrypted JSON file %q", name)
+		}
+		if _, exists := result.Files[name]; exists {
+			continue
+		}
+		result.Files[name], err = readStableRegularFile(filepath.Join(profile, name))
+		if err != nil {
+			result.clear()
+			return snapshotData{}, fmt.Errorf("read %s: %w", name, err)
+		}
+	}
+	return result, nil
+}
+
+func readStableRegularFile(path string) ([]byte, error) {
+	before, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !before.Mode().IsRegular() {
+		return nil, errors.New("file is not regular")
+	}
+	if before.Size() > maxFileBytes {
+		return nil, fmt.Errorf("file exceeds %d bytes", maxFileBytes)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !os.SameFile(before, opened) {
+		return nil, errors.New("file changed while opening")
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxFileBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxFileBytes {
+		return nil, fmt.Errorf("file exceeds %d bytes", maxFileBytes)
+	}
+	after, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !os.SameFile(opened, after) || opened.Size() != after.Size() || !opened.ModTime().Equal(after.ModTime()) {
+		return nil, errors.New("file changed while reading")
+	}
+	return data, nil
+}
+
+func readKeychainSecret(ctx context.Context) ([]byte, error) {
+	if runtime.GOOS != "darwin" {
+		return nil, errors.New("unsupported platform")
+	}
+	cmd := exec.CommandContext(ctx, "/usr/bin/security", "find-generic-password", "-s", keychainService, "-a", keychainAccount, "-w")
+	cmd.Stderr = io.Discard
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	output = bytes.TrimRight(output, "\r\n")
+	if len(output) == 0 {
+		return nil, errors.New("empty Keychain secret")
+	}
+	return output, nil
+}
+
+func unwrapDEK(password, wrapped []byte) ([]byte, error) {
+	if len(wrapped) <= 3 || string(wrapped[:3]) != "v10" {
+		return nil, errors.New("unsupported safeStorage payload")
+	}
+	key := pbkdf2SHA1(password, []byte("saltysalt"), 1003, 16)
+	defer zero(key)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	ciphertext := wrapped[3:]
+	if len(ciphertext) == 0 || len(ciphertext)%aes.BlockSize != 0 {
+		return nil, errors.New("invalid safeStorage ciphertext")
+	}
+	plain := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(block, bytes.Repeat([]byte{' '}, aes.BlockSize)).CryptBlocks(plain, ciphertext)
+	plain, err = unpadPKCS7(plain, aes.BlockSize)
+	if err != nil {
+		return nil, err
+	}
+	dek := make([]byte, base64.StdEncoding.DecodedLen(len(plain)))
+	n, err := base64.StdEncoding.Decode(dek, plain)
+	zero(plain)
+	dek = dek[:n]
+	if err != nil || len(dek) != 32 {
+		zero(dek)
+		return nil, errors.New("invalid data encryption key")
+	}
+	return dek, nil
+}
+
+func pbkdf2SHA1(password, salt []byte, iterations, keyLen int) []byte {
+	const hashLen = sha1.Size
+	blocks := (keyLen + hashLen - 1) / hashLen
+	derived := make([]byte, keyLen)
+	offset := 0
+	var blockIndex [4]byte
+	for block := 1; block <= blocks; block++ {
+		binary.BigEndian.PutUint32(blockIndex[:], uint32(block))
+		mac := hmac.New(sha1.New, password)
+		_, _ = mac.Write(salt)
+		_, _ = mac.Write(blockIndex[:])
+		u := mac.Sum(nil)
+		t := append([]byte(nil), u...)
+		for iteration := 1; iteration < iterations; iteration++ {
+			mac = hmac.New(sha1.New, password)
+			_, _ = mac.Write(u)
+			next := mac.Sum(nil)
+			for i := range t {
+				t[i] ^= next[i]
+			}
+			zero(u)
+			u = next
+		}
+		zero(u)
+		offset += copy(derived[offset:], t)
+		zero(t)
+	}
+	return derived
+}
+
+func decryptJSON(dek, encrypted []byte) (json.RawMessage, error) {
+	if len(dek) != 32 || len(encrypted) < 12+16 {
+		return nil, errors.New("invalid encrypted JSON payload")
+	}
+	block, err := aes.NewCipher(dek)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCMWithNonceSize(block, 12)
+	if err != nil {
+		return nil, err
+	}
+	plain, err := gcm.Open(nil, encrypted[:12], encrypted[12:], nil)
+	if err != nil {
+		return nil, err
+	}
+	if !json.Valid(plain) {
+		zero(plain)
+		return nil, errors.New("decrypted payload is not JSON")
+	}
+	return json.RawMessage(plain), nil
+}
+
+func unpadPKCS7(data []byte, blockSize int) ([]byte, error) {
+	if len(data) == 0 || len(data)%blockSize != 0 {
+		return nil, errors.New("invalid padding")
+	}
+	padding := int(data[len(data)-1])
+	if padding == 0 || padding > blockSize || padding > len(data) {
+		return nil, errors.New("invalid padding")
+	}
+	for _, value := range data[len(data)-padding:] {
+		if int(value) != padding {
+			return nil, errors.New("invalid padding")
+		}
+	}
+	return data[:len(data)-padding], nil
+}
+
+func zero(data []byte) {
+	for i := range data {
+		data[i] = 0
+	}
+}

--- a/internal/encryptedjson/encryptedjson_test.go
+++ b/internal/encryptedjson/encryptedjson_test.go
@@ -1,0 +1,138 @@
+package encryptedjson
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/pbkdf2"
+	"crypto/sha1"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDecryptSnapshotDecryptsCompatiblePayload(t *testing.T) {
+	password := "synthetic-keychain-secret"
+	dek := bytes.Repeat([]byte{0x42}, 32)
+	cache := []byte(`{"cache":{"version":8,"state":{"documents":{},"transcripts":{}}}}`)
+	snapshot := snapshotData{
+		StorageDEK: wrapDEK(t, password, dek),
+		Files: map[string][]byte{
+			CacheFile: encryptJSON(t, dek, cache),
+		},
+	}
+	secret := []byte(password)
+	files, err := decryptSnapshot(context.Background(), snapshot, func(context.Context) ([]byte, error) {
+		return secret, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer Clear(files)
+	if !bytes.Equal(files[CacheFile], cache) {
+		t.Fatalf("decrypted cache mismatch: %s", files[CacheFile])
+	}
+	if !bytes.Equal(secret, make([]byte, len(secret))) {
+		t.Fatal("decryptor did not clear Keychain secret buffer")
+	}
+}
+
+func TestDecryptSnapshotRedactsDeniedKeychainError(t *testing.T) {
+	snapshot := snapshotData{
+		StorageDEK: []byte("v10ciphertext"),
+		Files:      map[string][]byte{CacheFile: []byte("ciphertext")},
+	}
+	_, err := decryptSnapshot(context.Background(), snapshot, func(context.Context) ([]byte, error) {
+		return nil, errors.New("denied: synthetic-sensitive-detail")
+	})
+	if err == nil || strings.Contains(err.Error(), "synthetic-sensitive-detail") {
+		t.Fatalf("decryptor leaked Keychain error: %v", err)
+	}
+}
+
+func TestDecryptSnapshotRejectsTamperedCiphertext(t *testing.T) {
+	password := "synthetic-keychain-secret"
+	dek := bytes.Repeat([]byte{0x24}, 32)
+	encrypted := encryptJSON(t, dek, []byte(`{"ok":true}`))
+	encrypted[len(encrypted)-1] ^= 0xff
+	snapshot := snapshotData{
+		StorageDEK: wrapDEK(t, password, dek),
+		Files:      map[string][]byte{CacheFile: encrypted},
+	}
+	files, err := decryptSnapshot(context.Background(), snapshot, func(context.Context) ([]byte, error) {
+		return []byte(password), nil
+	})
+	if err == nil || len(files) != 0 {
+		t.Fatalf("tampered payload was not rejected: files=%d err=%v", len(files), err)
+	}
+}
+
+func TestDecryptSnapshotHonorsContextDeadline(t *testing.T) {
+	snapshot := snapshotData{
+		StorageDEK: []byte("v10ciphertext"),
+		Files:      map[string][]byte{CacheFile: []byte("ciphertext")},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err := decryptSnapshot(ctx, snapshot, func(ctx context.Context) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	if err == nil || !strings.Contains(err.Error(), "Keychain access") {
+		t.Fatalf("unexpected timeout error: %v", err)
+	}
+}
+
+func TestSnapshotRejectsSymlinkedInput(t *testing.T) {
+	profile := t.TempDir()
+	if err := os.WriteFile(filepath.Join(profile, "storage.dek"), []byte("wrapped"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(profile, "target")
+	if err := os.WriteFile(target, []byte("ciphertext"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(profile, CacheFile)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := snapshot(profile, []string{CacheFile}); err == nil || !strings.Contains(err.Error(), "not regular") {
+		t.Fatalf("expected symlink rejection, got %v", err)
+	}
+}
+
+func wrapDEK(t *testing.T, password string, dek []byte) []byte {
+	t.Helper()
+	plain := []byte(base64.StdEncoding.EncodeToString(dek))
+	padding := aes.BlockSize - len(plain)%aes.BlockSize
+	plain = append(plain, bytes.Repeat([]byte{byte(padding)}, padding)...)
+	key, err := pbkdf2.Key(sha1.New, password, []byte("saltysalt"), 1003, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted := make([]byte, len(plain))
+	cipher.NewCBCEncrypter(block, bytes.Repeat([]byte{' '}, aes.BlockSize)).CryptBlocks(encrypted, plain)
+	return append([]byte("v10"), encrypted...)
+}
+
+func encryptJSON(t *testing.T, dek, plain []byte) []byte {
+	t.Helper()
+	block, err := aes.NewCipher(dek)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcm, err := cipher.NewGCMWithNonceSize(block, 12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := bytes.Repeat([]byte{0x7a}, 12)
+	return append(nonce, gcm.Seal(nil, nonce, plain, nil)...)
+}

--- a/internal/granola/files.go
+++ b/internal/granola/files.go
@@ -2,7 +2,7 @@ package granola
 
 import "os"
 
-const EncryptedOnlyStateMessage = "Granola desktop state is encrypted-only; encrypted-json unlock/import is not implemented in this version; re-signing into Granola desktop will not fix this unless it emits plaintext supabase.json/cache-v6.json."
+const EncryptedOnlyStateMessage = "Granola desktop state is encrypted-only; rerun with explicit encrypted-json unlock enabled to read newer cache-v6.json.enc or supabase.json.enc, or use a current plaintext source."
 
 type FileState struct {
 	Path    string `json:"path"`

--- a/internal/granola/token.go
+++ b/internal/granola/token.go
@@ -39,11 +39,15 @@ type TokenSummary struct {
 }
 
 func ReadSupabase(path string) (SupabaseFile, WorkOSTokens, UserInfo, error) {
-	var file SupabaseFile
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return file, WorkOSTokens{}, UserInfo{}, err
+		return SupabaseFile{}, WorkOSTokens{}, UserInfo{}, err
 	}
+	return ParseSupabase(b)
+}
+
+func ParseSupabase(b []byte) (SupabaseFile, WorkOSTokens, UserInfo, error) {
+	var file SupabaseFile
 	if err := json.Unmarshal(b, &file); err != nil {
 		return file, WorkOSTokens{}, UserInfo{}, err
 	}

--- a/internal/security/report.go
+++ b/internal/security/report.go
@@ -52,7 +52,7 @@ func Sources(cfg config.Config) []SourceSupport {
 			Allowed:     cfg.Granola.AllowEncryptedJSON,
 			Implemented: false,
 			NeedsSecret: true,
-			Notes:       "unsupported in this build; encrypted-only Granola state requires future explicit unlock/import",
+			Notes:       "unlock surface only; use --unlock encrypted-json with private-api or desktop-cache",
 		},
 		{
 			Source:      model.SourceOPFS,
@@ -72,17 +72,20 @@ func Sources(cfg config.Config) []SourceSupport {
 }
 
 func Unlock(cfg config.Config) UnlockReport {
-	needsCompanion := cfg.Granola.AllowEncryptedJSON || cfg.Granola.AllowOPFS
 	mode := cfg.Security.KeychainPromptMode
 	return UnlockReport{
 		KeychainPromptMode: mode,
 		PersistHelperKeys:  cfg.Security.PersistHelperKeys,
 		EncryptedJSON:      cfg.Granola.AllowEncryptedJSON,
 		OPFS:               cfg.Granola.AllowOPFS,
-		RequiresCompanion:  needsCompanion,
-		PromptAllowed:      mode == "ask" || mode == "always",
-		Message:            unlockMessage(needsCompanion, mode),
+		RequiresCompanion:  false,
+		PromptAllowed:      PromptAllowed(mode),
+		Message:            unlockMessage(cfg.Granola.AllowEncryptedJSON, cfg.Granola.AllowOPFS, mode),
 	}
+}
+
+func PromptAllowed(mode string) bool {
+	return mode == "explicit" || mode == "ask" || mode == "always"
 }
 
 func Secrets(cfg config.Config) SecretReport {
@@ -91,13 +94,19 @@ func Secrets(cfg config.Config) SecretReport {
 		PersistHelperKeys:  cfg.Security.PersistHelperKeys,
 		KeychainPromptMode: cfg.Security.KeychainPromptMode,
 		GranolaKeychain:    "external",
-		Message:            "graincrawl does not persist Granola tokens; encrypted sources must unlock through an explicit helper flow",
+		Message:            "graincrawl does not persist Granola tokens; encrypted sources require an explicit unlock flow",
 	}
 }
 
-func unlockMessage(needsCompanion bool, mode string) string {
-	if !needsCompanion {
-		return "encrypted JSON and OPFS sources are disabled; encrypted-json unlock/import is not implemented in this version, and no keychain prompt is expected"
+func unlockMessage(encryptedJSON, opfs bool, mode string) string {
+	if !encryptedJSON && !opfs {
+		return "encrypted JSON and OPFS sources are disabled; no keychain prompt is expected"
 	}
-	return "encrypted local sources are configured, but encrypted-json/OPFS unlock/import is not implemented in this version; no companion helper or keychain prompt will run"
+	if encryptedJSON && PromptAllowed(mode) {
+		return "encrypted JSON unlock is available only through an explicit unlock command; OPFS remains unsupported"
+	}
+	if encryptedJSON {
+		return "encrypted JSON is enabled, but the current keychain prompt mode blocks unlock; OPFS remains unsupported"
+	}
+	return "OPFS is configured but unsupported in this build; no companion or keychain prompt will run"
 }

--- a/internal/security/report_test.go
+++ b/internal/security/report_test.go
@@ -1,0 +1,32 @@
+package security
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openclaw/graincrawl/internal/config"
+)
+
+func TestUnlockReportDoesNotRequireCompanion(t *testing.T) {
+	cfg := config.Config{
+		Granola:  config.GranolaConfig{AllowEncryptedJSON: true},
+		Security: config.SecurityConfig{KeychainPromptMode: "explicit"},
+	}
+	report := Unlock(cfg)
+	if report.RequiresCompanion {
+		t.Fatal("in-process encrypted JSON unlock must not require a companion")
+	}
+	if !report.PromptAllowed || !strings.Contains(report.Message, "explicit unlock") {
+		t.Fatalf("unexpected encrypted JSON unlock report: %#v", report)
+	}
+}
+
+func TestUnlockReportExplainsUnsupportedOPFSWithoutCompanion(t *testing.T) {
+	report := Unlock(config.Config{Granola: config.GranolaConfig{AllowOPFS: true}})
+	if report.RequiresCompanion {
+		t.Fatal("unsupported OPFS must not claim a running companion requirement")
+	}
+	if !strings.Contains(report.Message, "unsupported") || !strings.Contains(report.Message, "no companion") {
+		t.Fatalf("unexpected OPFS unlock report: %#v", report)
+	}
+}

--- a/internal/syncer/desktop_cache.go
+++ b/internal/syncer/desktop_cache.go
@@ -13,25 +13,37 @@ import (
 )
 
 func DesktopCache(ctx context.Context, cfg config.Config, st *store.Store, opts Options) (Result, error) {
-	source := model.SourceDesktopCache
-	started := time.Now().UTC()
-	result := Result{Source: source}
 	paths := granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath)
 	encryptedOnlyMessage := ""
 	if granola.EncryptedOnlyState(paths) {
 		encryptedOnlyMessage = granola.EncryptedOnlyStateMessage
 	}
 	if granola.EncryptedCacheState(paths) {
-		result.Message = encryptedOnlyMessage
+		result := Result{Source: model.SourceDesktopCache, Message: encryptedOnlyMessage}
 		return result, fmt.Errorf("desktop-cache source requires plaintext cache-v6.json: %s", encryptedOnlyMessage)
 	}
 	file, err := cachev6.Read(paths.CacheV6)
 	if err != nil {
+		result := Result{Source: model.SourceDesktopCache, Message: encryptedOnlyMessage}
 		if encryptedOnlyMessage != "" {
 			return result, fmt.Errorf("%w: %s", err, encryptedOnlyMessage)
 		}
 		return result, err
 	}
+	return importDesktopCache(ctx, st, opts, file, model.SourceDesktopCache, encryptedOnlyMessage)
+}
+
+func encryptedDesktopCache(ctx context.Context, st *store.Store, opts Options, raw []byte) (Result, error) {
+	file, err := cachev6.Parse(raw)
+	if err != nil {
+		return Result{Source: model.SourceEncryptedJSON}, err
+	}
+	return importDesktopCache(ctx, st, opts, file, model.SourceEncryptedJSON, "unlocked encrypted cache-v6.json in memory")
+}
+
+func importDesktopCache(ctx context.Context, st *store.Store, opts Options, file cachev6.File, source model.Source, message string) (Result, error) {
+	started := time.Now().UTC()
+	result := Result{Source: source, Message: message}
 	now := time.Now().UTC()
 	count := 0
 	for _, doc := range file.Cache.State.Documents {
@@ -48,6 +60,7 @@ func DesktopCache(ctx context.Context, cfg config.Config, st *store.Store, opts 
 		if err != nil {
 			return result, err
 		}
+		note.Source = source
 		if err := st.UpsertNote(ctx, note); err != nil {
 			return result, err
 		}
@@ -68,9 +81,6 @@ func DesktopCache(ctx context.Context, cfg config.Config, st *store.Store, opts 
 				result.Transcripts++
 			}
 		}
-	}
-	if encryptedOnlyMessage != "" {
-		result.Message = encryptedOnlyMessage
 	}
 	completed := time.Now().UTC()
 	_, _ = st.InsertSyncRun(ctx, model.SyncRun{Source: source, StartedAt: started, CompletedAt: completed, Status: "ok", Notes: result.Notes, Transcripts: result.Transcripts, Panels: result.Panels, Message: result.Message})

--- a/internal/syncer/private_api.go
+++ b/internal/syncer/private_api.go
@@ -23,6 +23,18 @@ func PrivateAPI(ctx context.Context, cfg config.Config, st *store.Store, opts Op
 	if err != nil {
 		return Result{}, err
 	}
+	return privateAPIWithSession(ctx, cfg, st, opts, tokens, user, "")
+}
+
+func privateAPIFromEncryptedSupabase(ctx context.Context, cfg config.Config, st *store.Store, opts Options, raw []byte) (Result, error) {
+	_, tokens, user, err := granola.ParseSupabase(raw)
+	if err != nil {
+		return Result{}, err
+	}
+	return privateAPIWithSession(ctx, cfg, st, opts, tokens, user, "used encrypted supabase.json credentials in memory")
+}
+
+func privateAPIWithSession(ctx context.Context, cfg config.Config, st *store.Store, opts Options, tokens granola.WorkOSTokens, user granola.UserInfo, message string) (Result, error) {
 	summary := granola.SummarizeToken(tokens, time.Now())
 	if !summary.Present {
 		return Result{}, ErrPrivateAPITokenNotFound
@@ -49,13 +61,13 @@ func PrivateAPI(ctx context.Context, cfg config.Config, st *store.Store, opts Op
 			return Result{}, err
 		}
 	}
-	return syncPrivate(ctx, client, st, opts, cfg.API.IncludeSharedWithMe)
+	return syncPrivateWithMessage(ctx, client, st, opts, cfg.API.IncludeSharedWithMe, message)
 }
 
-func syncPrivate(ctx context.Context, client privateapi.Client, st *store.Store, opts Options, includeShared bool) (Result, error) {
+func syncPrivateWithMessage(ctx context.Context, client privateapi.Client, st *store.Store, opts Options, includeShared bool, message string) (Result, error) {
 	source := model.SourcePrivateAPI
 	started := time.Now().UTC()
-	result := Result{Source: source}
+	result := Result{Source: source, Message: message}
 	docs, err := client.GetDocuments(ctx, privateapi.DocumentsRequest{IncludeSharedWithMe: includeShared})
 	if err != nil {
 		return result, err
@@ -122,7 +134,7 @@ func syncPrivate(ctx context.Context, client privateapi.Client, st *store.Store,
 		}
 	}
 	completed := time.Now().UTC()
-	_, _ = st.InsertSyncRun(ctx, model.SyncRun{Source: source, StartedAt: started, CompletedAt: completed, Status: "ok", Notes: result.Notes, Transcripts: result.Transcripts, Panels: result.Panels})
+	_, _ = st.InsertSyncRun(ctx, model.SyncRun{Source: source, StartedAt: started, CompletedAt: completed, Status: "ok", Notes: result.Notes, Transcripts: result.Transcripts, Panels: result.Panels, Message: result.Message})
 	return result, nil
 }
 

--- a/internal/syncer/private_api_test.go
+++ b/internal/syncer/private_api_test.go
@@ -36,7 +36,7 @@ func TestSyncPrivateHydratesDocumentBodyBeforeUpsert(t *testing.T) {
 	}
 	defer st.Close()
 	client := privateapi.Client{BaseURL: srv.URL, AccessToken: "token"}
-	if _, err := syncPrivate(ctx, client, st, Options{Source: model.SourcePrivateAPI, Limit: 1}, false); err != nil {
+	if _, err := syncPrivateWithMessage(ctx, client, st, Options{Source: model.SourcePrivateAPI, Limit: 1}, false, ""); err != nil {
 		t.Fatal(err)
 	}
 	note, ok, err := st.GetNote(ctx, "doc-1")

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -6,12 +6,18 @@ import (
 	"fmt"
 
 	"github.com/openclaw/graincrawl/internal/config"
+	"github.com/openclaw/graincrawl/internal/encryptedjson"
 	"github.com/openclaw/graincrawl/internal/granola"
 	"github.com/openclaw/graincrawl/internal/model"
+	"github.com/openclaw/graincrawl/internal/security"
 	"github.com/openclaw/graincrawl/internal/store"
 )
 
 func Run(ctx context.Context, cfg config.Config, st *store.Store, opts Options) (Result, error) {
+	decrypt, err := encryptedJSONDecryptor(cfg, opts)
+	if err != nil {
+		return Result{}, err
+	}
 	sourceExplicit := opts.Source != ""
 	if opts.Source == "" {
 		opts.Source = model.Source(cfg.Granola.PreferredSource)
@@ -27,27 +33,96 @@ func Run(ctx context.Context, cfg config.Config, st *store.Store, opts Options) 
 			return Result{}, fmt.Errorf("private-api source disabled in config")
 		}
 		encryptedSupabase := granola.EncryptedSupabaseState(granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath))
-		if encryptedSupabase && !sourceExplicit && cfg.Granola.AllowDesktopCache {
+		if encryptedSupabase && decrypt == nil && !sourceExplicit && cfg.Granola.AllowDesktopCache {
 			opts.Source = model.SourceDesktopCache
-			return DesktopCache(ctx, cfg, st, opts)
+			return runDesktopCache(ctx, cfg, st, opts, decrypt)
 		}
 		if encryptedSupabase {
-			return Result{Source: model.SourcePrivateAPI, Message: granola.EncryptedOnlyStateMessage}, fmt.Errorf("private-api source requires plaintext supabase.json: %s", granola.EncryptedOnlyStateMessage)
+			if decrypt == nil {
+				return Result{Source: model.SourcePrivateAPI, Message: granola.EncryptedOnlyStateMessage}, fmt.Errorf("private-api source requires plaintext supabase.json: %s", granola.EncryptedOnlyStateMessage)
+			}
+			paths := granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath)
+			names := []string{encryptedjson.SupabaseFile}
+			encryptedCacheFallback := !sourceExplicit && cfg.Granola.AllowDesktopCache && granola.EncryptedCacheState(paths)
+			if encryptedCacheFallback {
+				names = append(names, encryptedjson.CacheFile)
+			}
+			files, err := decrypt(ctx, paths.Root, names...)
+			if err != nil {
+				return Result{Source: model.SourcePrivateAPI}, err
+			}
+			defer encryptedjson.Clear(files)
+			raw, ok := files[encryptedjson.SupabaseFile]
+			if !ok {
+				return Result{Source: model.SourcePrivateAPI}, fmt.Errorf("encrypted storage decryptor omitted %s", encryptedjson.SupabaseFile)
+			}
+			result, err := privateAPIFromEncryptedSupabase(ctx, cfg, st, opts, raw)
+			if err != nil && !sourceExplicit && cfg.Granola.AllowDesktopCache && privateAPIAuthUnavailable(err) {
+				opts.Source = model.SourceDesktopCache
+				if encryptedCacheFallback {
+					cache, ok := files[encryptedjson.CacheFile]
+					if !ok {
+						return Result{Source: model.SourceEncryptedJSON}, fmt.Errorf("encrypted storage decryptor omitted %s", encryptedjson.CacheFile)
+					}
+					return encryptedDesktopCache(ctx, st, opts, cache)
+				}
+				return runDesktopCache(ctx, cfg, st, opts, nil)
+			}
+			return result, err
 		}
 		result, err := PrivateAPI(ctx, cfg, st, opts)
 		if err != nil && !sourceExplicit && cfg.Granola.AllowDesktopCache && privateAPIAuthUnavailable(err) {
 			opts.Source = model.SourceDesktopCache
-			return DesktopCache(ctx, cfg, st, opts)
+			return runDesktopCache(ctx, cfg, st, opts, decrypt)
 		}
 		return result, err
 	case model.SourceDesktopCache:
-		if !cfg.Granola.AllowDesktopCache {
-			return Result{}, fmt.Errorf("desktop-cache source disabled in config")
-		}
-		return DesktopCache(ctx, cfg, st, opts)
+		return runDesktopCache(ctx, cfg, st, opts, decrypt)
 	default:
 		return Result{}, fmt.Errorf("source %q is disabled or unsupported in this build", opts.Source)
 	}
+}
+
+func runDesktopCache(ctx context.Context, cfg config.Config, st *store.Store, opts Options, decrypt encryptedjson.DecryptFunc) (Result, error) {
+	if !cfg.Granola.AllowDesktopCache {
+		return Result{}, fmt.Errorf("desktop-cache source disabled in config")
+	}
+	paths := granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath)
+	if granola.EncryptedCacheState(paths) {
+		if decrypt == nil {
+			return DesktopCache(ctx, cfg, st, opts)
+		}
+		files, err := decrypt(ctx, paths.Root, encryptedjson.CacheFile)
+		if err != nil {
+			return Result{Source: model.SourceEncryptedJSON}, err
+		}
+		defer encryptedjson.Clear(files)
+		raw, ok := files[encryptedjson.CacheFile]
+		if !ok {
+			return Result{Source: model.SourceEncryptedJSON}, fmt.Errorf("encrypted storage decryptor omitted %s", encryptedjson.CacheFile)
+		}
+		return encryptedDesktopCache(ctx, st, opts, raw)
+	}
+	return DesktopCache(ctx, cfg, st, opts)
+}
+
+func encryptedJSONDecryptor(cfg config.Config, opts Options) (encryptedjson.DecryptFunc, error) {
+	if opts.UnlockSurface == "" {
+		return nil, nil
+	}
+	if opts.UnlockSurface != "encrypted-json" {
+		return nil, fmt.Errorf("unsupported unlock surface %q", opts.UnlockSurface)
+	}
+	if !cfg.Granola.AllowEncryptedJSON {
+		return nil, fmt.Errorf("encrypted-json source disabled in config")
+	}
+	if !security.PromptAllowed(cfg.Security.KeychainPromptMode) {
+		return nil, fmt.Errorf("keychain prompt mode %q blocks encrypted-json unlock", cfg.Security.KeychainPromptMode)
+	}
+	if opts.DecryptEncryptedJSON != nil {
+		return opts.DecryptEncryptedJSON, nil
+	}
+	return encryptedjson.Decrypt, nil
 }
 
 func privateAPIAuthUnavailable(err error) bool {

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/openclaw/graincrawl/internal/config"
+	"github.com/openclaw/graincrawl/internal/encryptedjson"
 	"github.com/openclaw/graincrawl/internal/model"
 	"github.com/openclaw/graincrawl/internal/store"
 )
@@ -267,6 +269,177 @@ func TestRunFallsBackToDesktopCacheForImplicitExpiredPrivateAPI(t *testing.T) {
 	}
 	if _, err := Run(ctx, cfg, st, Options{Source: model.SourcePrivateAPI}); !errors.Is(err, ErrPrivateAPITokenExpired) {
 		t.Fatalf("explicit private-api should still fail with token expiry, got %v", err)
+	}
+}
+
+func TestRunImportsEncryptedDesktopCacheOnlyWithExplicitUnlock(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(profile, "cache-v6.json")
+	cacheEncPath := filepath.Join(profile, encryptedjson.CacheFile)
+	if err := os.WriteFile(cachePath, []byte(`{"cache":{"version":8,"state":{"documents":{},"transcripts":{}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cacheEncPath, []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	makeNewer(t, cachePath, cacheEncPath)
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:        profile,
+			AllowDesktopCache:  true,
+			AllowEncryptedJSON: true,
+		},
+		Security: config.SecurityConfig{KeychainPromptMode: "explicit"},
+		Sync:     config.SyncConfig{DefaultLimit: 100},
+	}
+	cacheRaw := json.RawMessage(`{"cache":{"version":8,"state":{"documents":{"doc1":{"id":"doc1","created_at":"2026-05-06T01:00:00Z","updated_at":"2026-05-06T02:00:00Z","title":"Encrypted","type":"meeting","notes_plain":"private"}},"transcripts":{}}}}`)
+	calls := 0
+	result, err := Run(ctx, cfg, st, Options{
+		Source:        model.SourceDesktopCache,
+		UnlockSurface: "encrypted-json",
+		DecryptEncryptedJSON: func(_ context.Context, _ string, names ...string) (map[string]json.RawMessage, error) {
+			calls++
+			if len(names) != 1 || names[0] != encryptedjson.CacheFile {
+				t.Fatalf("unexpected requested files: %v", names)
+			}
+			return map[string]json.RawMessage{encryptedjson.CacheFile: cacheRaw}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 || result.Source != model.SourceEncryptedJSON || result.Notes != 1 {
+		t.Fatalf("unexpected encrypted import result: calls=%d result=%#v", calls, result)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Notes != 1 {
+		t.Fatalf("expected one archived note, got %#v", status)
+	}
+}
+
+func TestRunEncryptedUnlockRequiresConfigApproval(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:       filepath.Join(root, "Granola"),
+			AllowDesktopCache: true,
+		},
+		Security: config.SecurityConfig{KeychainPromptMode: "explicit"},
+	}
+	_, err = Run(ctx, cfg, st, Options{
+		Source:        model.SourceDesktopCache,
+		UnlockSurface: "encrypted-json",
+		DecryptEncryptedJSON: func(context.Context, string, ...string) (map[string]json.RawMessage, error) {
+			t.Fatal("decryptor should not run without config approval")
+			return nil, nil
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "disabled in config") {
+		t.Fatalf("expected config rejection, got %v", err)
+	}
+}
+
+func TestRunEncryptedSupabaseChecksDecryptedToken(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, encryptedjson.SupabaseFile), []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cachePath := filepath.Join(profile, "cache-v6.json")
+	cacheEncryptedPath := filepath.Join(profile, encryptedjson.CacheFile)
+	if err := os.WriteFile(cachePath, []byte(`{"cache":{"version":8,"state":{"transcripts":{}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cacheEncryptedPath, []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	makeNewer(t, cachePath, cacheEncryptedPath)
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:        profile,
+			PreferredSource:    "private-api",
+			AllowPrivateAPI:    true,
+			AllowDesktopCache:  true,
+			AllowEncryptedJSON: true,
+		},
+		Security: config.SecurityConfig{KeychainPromptMode: "explicit"},
+		Sync:     config.SyncConfig{DefaultLimit: 100},
+	}
+	expired := json.RawMessage(`{"workos_tokens":"{\"access_token\":\"synthetic-expired\",\"obtained_at\":0,\"expires_in\":1}"}`)
+	cache := json.RawMessage(`{"cache":{"version":8,"state":{"transcripts":{}}}}`)
+	decryptCalls := 0
+	decrypt := func(_ context.Context, _ string, names ...string) (map[string]json.RawMessage, error) {
+		decryptCalls++
+		if decryptCalls == 1 && (len(names) != 2 || names[0] != encryptedjson.SupabaseFile || names[1] != encryptedjson.CacheFile) {
+			t.Fatalf("implicit fallback should batch encrypted auth and cache, got %v", names)
+		}
+		if decryptCalls == 2 && (len(names) != 1 || names[0] != encryptedjson.SupabaseFile) {
+			t.Fatalf("explicit private-api should request only encrypted auth, got %v", names)
+		}
+		files := make(map[string]json.RawMessage, len(names))
+		for _, name := range names {
+			switch name {
+			case encryptedjson.SupabaseFile:
+				files[name] = append(json.RawMessage(nil), expired...)
+			case encryptedjson.CacheFile:
+				files[name] = append(json.RawMessage(nil), cache...)
+			default:
+				t.Fatalf("unexpected requested file: %s", name)
+			}
+		}
+		return files, nil
+	}
+	result, err := Run(ctx, cfg, st, Options{
+		UnlockSurface:        "encrypted-json",
+		DecryptEncryptedJSON: decrypt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Source != model.SourceEncryptedJSON {
+		t.Fatalf("expected implicit encrypted token expiry to fall back to encrypted cache, got %#v", result)
+	}
+	if decryptCalls != 1 {
+		t.Fatalf("expected one batched decrypt for implicit fallback, got %d", decryptCalls)
+	}
+	_, err = Run(ctx, cfg, st, Options{
+		Source:               model.SourcePrivateAPI,
+		UnlockSurface:        "encrypted-json",
+		DecryptEncryptedJSON: decrypt,
+	})
+	if !errors.Is(err, ErrPrivateAPITokenExpired) {
+		t.Fatalf("expected explicit decrypted token expiry, got %v", err)
+	}
+	if decryptCalls != 2 {
+		t.Fatalf("expected one decrypt per command, got %d total", decryptCalls)
 	}
 }
 

--- a/internal/syncer/types.go
+++ b/internal/syncer/types.go
@@ -1,14 +1,19 @@
 package syncer
 
-import "github.com/openclaw/graincrawl/internal/model"
+import (
+	"github.com/openclaw/graincrawl/internal/encryptedjson"
+	"github.com/openclaw/graincrawl/internal/model"
+)
 
 type Options struct {
-	Source             model.Source `json:"source"`
-	Limit              int          `json:"limit"`
-	IncludeTranscripts bool         `json:"include_transcripts"`
-	IncludePanels      bool         `json:"include_panels"`
-	SkipTranscripts    bool         `json:"-"`
-	SkipPanels         bool         `json:"-"`
+	Source               model.Source              `json:"source"`
+	Limit                int                       `json:"limit"`
+	IncludeTranscripts   bool                      `json:"include_transcripts"`
+	IncludePanels        bool                      `json:"include_panels"`
+	SkipTranscripts      bool                      `json:"-"`
+	SkipPanels           bool                      `json:"-"`
+	UnlockSurface        string                    `json:"-"`
+	DecryptEncryptedJSON encryptedjson.DecryptFunc `json:"-"`
 }
 
 type Result struct {


### PR DESCRIPTION
## Summary

- add an explicit macOS `encrypted-json` unlock path for modern Granola profiles
- decrypt `cache-v6.json.enc` for desktop-cache import and `supabase.json.enc` for private API authentication
- keep Keychain access behind `allow_encrypted_json = true` plus `unlock encrypted-json` or `--unlock encrypted-json`
- retain OPFS as unsupported and remove any hidden helper command path

## Security

- snapshot only the two allowlisted regular files before Keychain access, with stable-file and 64 MiB limits
- read `Granola Safe Storage` / `Granola Key` through `/usr/bin/security` with a 30-second timeout
- unwrap Chromium `v10` safeStorage data and AES-GCM payloads in memory; clear sensitive byte buffers where practical
- discard raw Keychain stderr and return redacted denial/decryption errors
- never persist decrypted Granola JSON, tokens, refresh tokens, or DEKs

## Verification

- `make check`
- `GOWORK=off go test -race -count=1 ./...`
- exact CI parity: gofmt, `go mod verify`, `deadcode -test ./...`, and `govulncheck ./...` (zero called vulnerabilities)
- `make smoke`
- `make release-snapshot`
- structured autoreview: clean, no accepted/actionable findings
- live E2E with signed Granola 7.309.0 and a fresh encrypted profile: exact build commit `0ca3cf5`, binary SHA-256 `906146c544dc6f863d1bb6bcb52de791a30bd6f97fc1985d79832d746abb1d0e`
- independent Granola API comparison: 6 source documents, 6 imported notes, exact ID hash `a00784ddc701035fc68eb286c2c655fc42201fe2c85742b32a912ead377aa421`, exact payload-pair hash `10de35db88cb74db132003345549d1071e973a1830aa429aac80a16252ae76d7`
- encrypted cache freshness selected over the older plaintext cache; restored and resynced profiles remained byte-identical before/after; zero Granola processes/open handles, secret-bearing output files, note-content output files, or decrypted source files
- denied Keychain access and tampered ciphertext are covered by redacted-error regression tests

Issue: https://github.com/openclaw/graincrawl/issues/22

Closes #22
