### PR TITLE
ci: refresh validation tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           git diff --exit-code -- go.mod go.sum
 
       - name: Install govulncheck
-        run: GOWORK=off go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+        run: GOWORK=off go install golang.org/x/vuln/cmd/govulncheck@v1.4.0
 
       - name: Run govulncheck
         run: GOWORK=off "$(go env GOPATH)/bin/govulncheck" ./...
@@ -70,7 +70,7 @@ jobs:
         run: GOWORK=off go vet ./...
 
       - name: Install deadcode
-        run: GOWORK=off go install golang.org/x/tools/cmd/deadcode@v0.45.0
+        run: GOWORK=off go install golang.org/x/tools/cmd/deadcode@v0.46.0
 
       - name: Deadcode
         run: |
@@ -138,7 +138,7 @@ jobs:
           cache: true
 
       - name: Snapshot release build
-        uses: goreleaser/goreleaser-action@v7.2.1
+        uses: goreleaser/goreleaser-action@v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@v3.95.5
+        uses: trufflesecurity/trufflehog@v3.95.6
         with:
           path: ./
           base: ${{ steps.scan_range.outputs.base }}


### PR DESCRIPTION
## Summary

- update `govulncheck` from v1.3.0 to v1.4.0
- update `deadcode` from v0.45.0 to v0.46.0
- update GoReleaser action from v7.2.1 to v7.2.2
- update TruffleHog from v3.95.5 to v3.95.6

All updates are current compatible releases; the Go tools require Go 1.25 while this repository uses Go 1.26.4.

## Verification

- `actionlint`
- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./...` (0 reachable vulnerabilities)
- `GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.46.0 -test ./...`
- Codex autoreview: clean, no accepted/actionable findings
