### PR TITLE
[codex] Treat archive search wildcards literally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update `golang.org/x/sys` to remove GO-2026-5024 from the Windows dependency graph.
 - Refresh terminal rendering, Unicode text, and SQLite runtime dependencies.
+- Treat `%`, `_`, and backslashes literally in archive search and update CrawlKit.
 
 ## v0.3.0 - 2026-06-11
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openclaw/graincrawl
 go 1.26.4
 
 require (
-	github.com/openclaw/crawlkit v0.12.2
+	github.com/openclaw/crawlkit v0.12.3-0.20260619123532-e74b0c4130c9
 	github.com/pelletier/go-toml/v2 v2.4.0
 	modernc.org/sqlite v1.52.0
 )

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.12.2 h1:KivYMOHfemLG9LrfKKI8A/FTDJpdFJyeOreCGbKCsXA=
-github.com/openclaw/crawlkit v0.12.2/go.mod h1:+Z9vrCgH8BJ/+3MMoMfnDyhXC9ON7bEDduGvp5TmmuM=
+github.com/openclaw/crawlkit v0.12.3-0.20260619123532-e74b0c4130c9 h1:fUhIOEUTF2d5LncUqUaqohbri656aV2XOQmG0uLyDIk=
+github.com/openclaw/crawlkit v0.12.3-0.20260619123532-e74b0c4130c9/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
 github.com/pelletier/go-toml/v2 v2.4.0 h1:Mwu0mAkUKbittDs3/ADDWXqMmq3EOK2VHiuCkV00Row=
 github.com/pelletier/go-toml/v2 v2.4.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	ckstore "github.com/openclaw/crawlkit/store"
 	"github.com/openclaw/graincrawl/internal/model"
 )
 
@@ -11,7 +12,7 @@ func (s *Store) SearchNotes(ctx context.Context, query string, limit int) ([]mod
 	if limit <= 0 {
 		limit = 50
 	}
-	needle := "%" + strings.ToLower(strings.TrimSpace(query)) + "%"
+	needle := "%" + ckstore.EscapeLike(strings.ToLower(strings.TrimSpace(query))) + "%"
 	rows, err := s.DB().QueryContext(ctx, `
 SELECT DISTINCT notes.id, notes.title, notes.type, notes.status, notes.created_at, notes.updated_at,
   notes.deleted_at, notes.workspace_id, notes.calendar_event_id, notes.notes_plain,
@@ -20,14 +21,14 @@ SELECT DISTINCT notes.id, notes.title, notes.type, notes.status, notes.created_a
 FROM notes
 LEFT JOIN transcript_chunks ON transcript_chunks.document_id = notes.id
 LEFT JOIN document_panels ON document_panels.document_id = notes.id
-WHERE lower(coalesce(notes.title, '')) LIKE ?
-   OR lower(coalesce(notes.notes_plain, '')) LIKE ?
-   OR lower(coalesce(notes.notes_markdown, '')) LIKE ?
-   OR lower(coalesce(notes.summary_text, '')) LIKE ?
-   OR lower(coalesce(notes.summary_markdown, '')) LIKE ?
-   OR lower(coalesce(transcript_chunks.text, '')) LIKE ?
-   OR lower(coalesce(document_panels.content_plain, '')) LIKE ?
-   OR lower(coalesce(document_panels.content_markdown, '')) LIKE ?
+WHERE lower(coalesce(notes.title, '')) LIKE ? ESCAPE '\'
+   OR lower(coalesce(notes.notes_plain, '')) LIKE ? ESCAPE '\'
+   OR lower(coalesce(notes.notes_markdown, '')) LIKE ? ESCAPE '\'
+   OR lower(coalesce(notes.summary_text, '')) LIKE ? ESCAPE '\'
+   OR lower(coalesce(notes.summary_markdown, '')) LIKE ? ESCAPE '\'
+   OR lower(coalesce(transcript_chunks.text, '')) LIKE ? ESCAPE '\'
+   OR lower(coalesce(document_panels.content_plain, '')) LIKE ? ESCAPE '\'
+   OR lower(coalesce(document_panels.content_markdown, '')) LIKE ? ESCAPE '\'
 ORDER BY notes.updated_at DESC
 LIMIT ?`, needle, needle, needle, needle, needle, needle, needle, needle, limit)
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -32,6 +32,13 @@ func TestStoreRoundTrip(t *testing.T) {
 	if err := st.UpsertNote(ctx, note); err != nil {
 		t.Fatal(err)
 	}
+	percentTitle := "100% Ready"
+	percentNote := note
+	percentNote.ID = "note-2"
+	percentNote.Title = &percentTitle
+	if err := st.UpsertNote(ctx, percentNote); err != nil {
+		t.Fatal(err)
+	}
 	got, ok, err := st.GetNote(ctx, "note-1")
 	if err != nil {
 		t.Fatal(err)
@@ -45,5 +52,19 @@ func TestStoreRoundTrip(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].ID != note.ID {
 		t.Fatalf("unexpected search results: %#v", results)
+	}
+	literalPercent, err := st.SearchNotes(ctx, "%", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(literalPercent) != 1 || literalPercent[0].ID != percentNote.ID {
+		t.Fatalf("literal percent search results: %#v", literalPercent)
+	}
+	literalUnderscore, err := st.SearchNotes(ctx, "_", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(literalUnderscore) != 0 {
+		t.Fatalf("literal underscore search results: %#v", literalUnderscore)
 	}
 }


### PR DESCRIPTION
## Summary

- treat `%`, `_`, and backslashes as literal archive search input instead of SQL LIKE operators
- use CrawlKit's shared LIKE escaping helper across all searched note/transcript/panel fields
- update CrawlKit to consume the shared helper
- add regression coverage proving wildcard searches do not match unrelated notes

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- autoreview: clean
