### PR TITLE
feat: retain explicit deletion tombstones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Preserve explicit Granola deletions as note, transcript, panel, and source-object tombstones, and make portable snapshot imports merge by default with explicit `--replace` restores.
+
 ## v0.3.2 - 2026-07-09
 
 - Add Developer ID signing and pre-publish verification for official macOS archives.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ graincrawl secrets
 graincrawl export markdown --out ./granola-notes
 graincrawl snapshot create --out ./graincrawl-snapshot
 graincrawl import ./graincrawl-snapshot
+graincrawl import --replace ./graincrawl-snapshot
 graincrawl tui
 graincrawl completion zsh
 ```
@@ -92,6 +93,10 @@ dashboards.
 
 `graincrawl snapshot create` and `graincrawl import` use `crawlkit/snapshot` so
 archives can move between machines without touching the live Granola profile.
+Imports merge into the local archive by default. Use `graincrawl import
+--replace <snapshot-dir>` only for an explicit exact restore that removes rows
+not present in the snapshot. Merge mode keeps existing local payloads on
+identity conflicts while preserving any tombstone found on either side.
 
 `graincrawl tui` uses `crawlkit/tui` over archived notes. The detail pane is
 fed from SQLite, including note text, transcript chunks, panels, and retained

--- a/internal/cachev6/normalize.go
+++ b/internal/cachev6/normalize.go
@@ -25,7 +25,7 @@ func NoteFromDocument(doc Document, now time.Time) (model.Note, error) {
 	if noteType == "" {
 		noteType = "meeting"
 	}
-	return model.Note{
+	note := model.Note{
 		ID:            doc.ID,
 		Title:         doc.Title,
 		Type:          noteType,
@@ -39,7 +39,12 @@ func NoteFromDocument(doc Document, now time.Time) (model.Note, error) {
 		Source:        model.SourceDesktopCache,
 		PayloadHash:   hashutil.JSON(doc),
 		LastSeenAt:    now,
-	}, nil
+	}
+	if deleted != nil {
+		note.DeletionSource = string(model.SourceDesktopCache)
+		note.DeletionReason = "source-deleted-at"
+	}
+	return note, nil
 }
 
 func TranscriptFromCache(chunk TranscriptChunk) (model.TranscriptChunk, error) {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -120,6 +120,7 @@ func (a App) runSync(ctx context.Context, w io.Writer, flags GlobalFlags, args [
 	output.PrintKV(w, "notes", result.Notes)
 	output.PrintKV(w, "transcripts", result.Transcripts)
 	output.PrintKV(w, "panels", result.Panels)
+	output.PrintKV(w, "deleted", result.Deleted)
 	if result.Message != "" {
 		output.PrintKV(w, "message", result.Message)
 	}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -28,7 +28,8 @@ Commands:
   secrets                 Inspect graincrawl-managed secret state.
   export markdown         Export notes as Markdown.
   snapshot create         Create a portable crawlkit snapshot.
-  import <path>           Import a portable crawlkit snapshot.
+  import [--replace] <path>
+                          Merge a portable snapshot; --replace restores exactly.
   tui                     Browse archived notes in the terminal.
   completion              Print shell completion for bash or zsh.
 

--- a/internal/cli/snapshot.go
+++ b/internal/cli/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/openclaw/graincrawl/internal/output"
@@ -38,37 +39,50 @@ func (a App) runSnapshot(ctx context.Context, w io.Writer, flags GlobalFlags, ar
 }
 
 func (a App) runImport(ctx context.Context, w io.Writer, flags GlobalFlags, args []string) error {
-	path := importPath(args)
-	if path == "" {
-		return fmt.Errorf("usage: graincrawl import <snapshot-dir>")
+	path, replace, err := parseImportArgs(args)
+	if err != nil {
+		return err
 	}
 	rt, err := gruntime.Open(ctx, flags.ConfigPath)
 	if err != nil {
 		return err
 	}
 	defer rt.Close()
-	manifest, err := portable.Import(ctx, rt.Store, portable.Options{RootDir: path})
+	manifest, err := portable.Import(ctx, rt.Store, portable.Options{RootDir: path, Replace: replace})
 	if err != nil {
 		return err
 	}
-	result := map[string]any{"snapshot_dir": path, "manifest": manifest}
+	mode := "merge"
+	if replace {
+		mode = "replace"
+	}
+	result := map[string]any{"snapshot_dir": path, "mode": mode, "manifest": manifest}
 	if flags.JSON {
 		return output.WriteEnvelope(w, result)
 	}
 	output.PrintKV(w, "imported", path)
+	output.PrintKV(w, "mode", mode)
 	output.PrintKV(w, "tables", len(manifest.Tables))
 	return nil
 }
 
-func importPath(args []string) string {
-	if len(args) == 0 {
-		return ""
-	}
-	if args[0] == "snapshot" || args[0] == "import" {
-		if len(args) > 1 {
-			return args[1]
+func parseImportArgs(args []string) (string, bool, error) {
+	var path string
+	var replace bool
+	for _, arg := range args {
+		switch {
+		case arg == "--replace":
+			replace = true
+		case strings.HasPrefix(arg, "-"):
+			return "", false, fmt.Errorf("unknown import flag %q", arg)
+		case path == "":
+			path = arg
+		default:
+			return "", false, fmt.Errorf("usage: graincrawl import [--replace] <snapshot-dir>")
 		}
-		return ""
 	}
-	return args[0]
+	if path == "" {
+		return "", false, fmt.Errorf("usage: graincrawl import [--replace] <snapshot-dir>")
+	}
+	return path, replace, nil
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -21,6 +21,8 @@ type Note struct {
 	CreatedAt       time.Time  `json:"created_at"`
 	UpdatedAt       time.Time  `json:"updated_at"`
 	DeletedAt       *time.Time `json:"deleted_at,omitempty"`
+	DeletionSource  string     `json:"deletion_source,omitempty"`
+	DeletionReason  string     `json:"deletion_reason,omitempty"`
 	WorkspaceID     *string    `json:"workspace_id,omitempty"`
 	CalendarEventID *string    `json:"calendar_event_id,omitempty"`
 	NotesPlain      *string    `json:"notes_plain,omitempty"`
@@ -33,15 +35,18 @@ type Note struct {
 }
 
 type TranscriptChunk struct {
-	ID                string    `json:"id"`
-	DocumentID        string    `json:"document_id"`
-	StartTimestamp    time.Time `json:"start_timestamp"`
-	EndTimestamp      time.Time `json:"end_timestamp"`
-	Source            string    `json:"source"`
-	IsFinal           bool      `json:"is_final"`
-	TranscriberUserID *string   `json:"transcriber_user_id,omitempty"`
-	Text              string    `json:"text"`
-	PayloadHash       string    `json:"payload_hash,omitempty"`
+	ID                string     `json:"id"`
+	DocumentID        string     `json:"document_id"`
+	StartTimestamp    time.Time  `json:"start_timestamp"`
+	EndTimestamp      time.Time  `json:"end_timestamp"`
+	Source            string     `json:"source"`
+	IsFinal           bool       `json:"is_final"`
+	TranscriberUserID *string    `json:"transcriber_user_id,omitempty"`
+	Text              string     `json:"text"`
+	PayloadHash       string     `json:"payload_hash,omitempty"`
+	DeletedAt         *time.Time `json:"deleted_at,omitempty"`
+	DeletionSource    string     `json:"deletion_source,omitempty"`
+	DeletionReason    string     `json:"deletion_reason,omitempty"`
 }
 
 type Panel struct {
@@ -58,6 +63,9 @@ type Panel struct {
 	YdocVersion     *int64     `json:"ydoc_version,omitempty"`
 	YdocCachedAt    *time.Time `json:"ydoc_cached_at,omitempty"`
 	Source          Source     `json:"source"`
+	DeletedAt       *time.Time `json:"deleted_at,omitempty"`
+	DeletionSource  string     `json:"deletion_source,omitempty"`
+	DeletionReason  string     `json:"deletion_reason,omitempty"`
 }
 
 type SyncRun struct {

--- a/internal/portable/snapshot.go
+++ b/internal/portable/snapshot.go
@@ -2,10 +2,15 @@ package portable
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	cksnapshot "github.com/openclaw/crawlkit/snapshot"
+	ckstore "github.com/openclaw/crawlkit/store"
 	"github.com/openclaw/graincrawl/internal/store"
 )
 
@@ -20,6 +25,7 @@ var Tables = []string{
 
 type Options struct {
 	RootDir string
+	Replace bool
 }
 
 type Manifest = cksnapshot.Manifest
@@ -33,11 +39,81 @@ func Export(ctx context.Context, st *store.Store, opts Options) (Manifest, error
 }
 
 func Import(ctx context.Context, st *store.Store, opts Options) (Manifest, error) {
-	return cksnapshot.Import(ctx, cksnapshot.ImportOptions{
-		DB:           st.DB(),
-		RootDir:      opts.RootDir,
-		DeleteTables: Tables,
-	})
+	importOpts := cksnapshot.ImportOptions{
+		DB:      st.DB(),
+		RootDir: opts.RootDir,
+		AfterImport: func(ctx context.Context, tx *sql.Tx) error {
+			return store.ReconcileTombstones(ctx, tx)
+		},
+	}
+	if opts.Replace {
+		importOpts.DeleteTables = Tables
+	} else {
+		importOpts.DeleteTable = func(context.Context, *sql.Tx, string) error { return nil }
+		importOpts.ImportRow = mergeRow
+	}
+	return cksnapshot.Import(ctx, importOpts)
+}
+
+var conflictColumns = map[string][]string{
+	"source_objects":    {"source", "kind", "source_id"},
+	"notes":             {"id"},
+	"transcript_chunks": {"id"},
+	"document_panels":   {"id"},
+	"sync_runs":         {"id"},
+	"source_state":      {"source", "entity_type", "entity_id"},
+}
+
+func mergeRow(ctx context.Context, tx *sql.Tx, table string, row map[string]any) error {
+	keys, ok := conflictColumns[table]
+	if !ok {
+		return fmt.Errorf("snapshot contains unsupported table %q", table)
+	}
+	cols := make([]string, 0, len(row))
+	for col := range row {
+		cols = append(cols, col)
+	}
+	sort.Strings(cols)
+	quoted := make([]string, 0, len(cols))
+	holders := make([]string, 0, len(cols))
+	args := make([]any, 0, len(cols))
+	updates := make([]string, 0, 3)
+	keySet := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		keySet[key] = struct{}{}
+	}
+	for _, col := range cols {
+		quotedCol := ckstore.QuoteIdent(col)
+		quoted = append(quoted, quotedCol)
+		holders = append(holders, "?")
+		args = append(args, row[col])
+		if _, isKey := keySet[col]; isKey {
+			continue
+		}
+		switch col {
+		case "deleted_at":
+			updates = append(updates, fmt.Sprintf("%s=COALESCE(%s.%s, excluded.%s)", quotedCol, ckstore.QuoteIdent(table), quotedCol, quotedCol))
+		case "deletion_source", "deletion_reason":
+			updates = append(updates, fmt.Sprintf("%s=COALESCE(NULLIF(%s.%s, ''), excluded.%s)", quotedCol, ckstore.QuoteIdent(table), quotedCol, quotedCol))
+		}
+	}
+	conflict := make([]string, 0, len(keys))
+	for _, key := range keys {
+		conflict = append(conflict, ckstore.QuoteIdent(key))
+	}
+	action := "DO NOTHING"
+	if len(updates) > 0 {
+		action = "DO UPDATE SET " + strings.Join(updates, ",")
+	}
+	stmt := fmt.Sprintf(
+		"INSERT INTO %s(%s) VALUES(%s) ON CONFLICT(%s) %s",
+		ckstore.QuoteIdent(table), strings.Join(quoted, ","), strings.Join(holders, ","),
+		strings.Join(conflict, ","), action,
+	)
+	if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
+		return fmt.Errorf("merge %s row: %w", table, err)
+	}
+	return nil
 }
 
 func DefaultDir(root string, now time.Time) string {

--- a/internal/portable/snapshot_test.go
+++ b/internal/portable/snapshot_test.go
@@ -1,0 +1,126 @@
+package portable
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openclaw/graincrawl/internal/model"
+	"github.com/openclaw/graincrawl/internal/store"
+)
+
+func TestImportMergesByDefaultAndReplaceIsExplicit(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	source := openTestStore(t, ctx, "source.db")
+	defer source.Close()
+	upsertTestNote(t, ctx, source, "snapshot-only", "Snapshot note", now)
+	upsertTestNote(t, ctx, source, "shared-id", "Snapshot version", now)
+	deletedAt := now.Add(time.Hour)
+	deletedTitle := "Legacy deleted note"
+	if err := source.UpsertNote(ctx, model.Note{
+		ID: "legacy-deleted", Title: &deletedTitle, Type: "meeting", CreatedAt: now,
+		UpdatedAt: now, DeletedAt: &deletedAt, Source: model.SourcePrivateAPI, LastSeenAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := source.UpsertTranscriptChunk(ctx, model.TranscriptChunk{
+		ID: "legacy-chunk", DocumentID: "legacy-deleted", StartTimestamp: now,
+		EndTimestamp: now.Add(time.Second), Source: "mic", Text: "retained",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := source.UpsertSourceObject(ctx, store.SourceObject{
+		Source: model.SourcePrivateAPI, Kind: "document", SourceID: "legacy-deleted",
+		DocumentID: "legacy-deleted", PayloadJSON: `{}`, PayloadHash: "hash", ObservedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	snapshotDir := filepath.Join(t.TempDir(), "snapshot")
+	if _, err := Export(ctx, source, Options{RootDir: snapshotDir}); err != nil {
+		t.Fatal(err)
+	}
+
+	destination := openTestStore(t, ctx, "destination.db")
+	defer destination.Close()
+	upsertTestNote(t, ctx, destination, "destination-only", "Local note", now)
+	upsertTestNote(t, ctx, destination, "shared-id", "Local version", now)
+	if err := destination.TombstoneDocument(ctx, "shared-id", store.Deletion{
+		At: now.Add(time.Hour), Source: model.SourcePrivateAPI, Reason: store.DeletionReasonExplicitFeed,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Import(ctx, destination, Options{RootDir: snapshotDir}); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"destination-only", "snapshot-only", "shared-id"} {
+		if _, ok, err := destination.GetNote(ctx, id); err != nil || !ok {
+			t.Fatalf("merged note %s: ok=%v err=%v", id, ok, err)
+		}
+	}
+	shared, _, err := destination.GetNote(ctx, "shared-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shared.DeletedAt == nil || shared.DeletionReason != store.DeletionReasonExplicitFeed {
+		t.Fatalf("merge cleared tombstone: %#v", shared)
+	}
+	if shared.Title == nil || *shared.Title != "Local version" {
+		t.Fatalf("merge overwrote destination payload: %#v", shared)
+	}
+	assertImportedLegacyTombstones(t, ctx, destination)
+
+	if _, err := Import(ctx, destination, Options{RootDir: snapshotDir, Replace: true}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := destination.GetNote(ctx, "destination-only"); err != nil || ok {
+		t.Fatalf("replace retained destination-only note: ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := destination.GetNote(ctx, "snapshot-only"); err != nil || !ok {
+		t.Fatalf("replace lost snapshot note: ok=%v err=%v", ok, err)
+	}
+	assertImportedLegacyTombstones(t, ctx, destination)
+}
+
+func assertImportedLegacyTombstones(t *testing.T, ctx context.Context, st *store.Store) {
+	t.Helper()
+	note, ok, err := st.GetNote(ctx, "legacy-deleted")
+	if err != nil || !ok || note.DeletedAt == nil || note.DeletionSource != string(model.SourcePrivateAPI) || note.DeletionReason != store.DeletionReasonLegacyField {
+		t.Fatalf("legacy imported note: ok=%v err=%v note=%#v", ok, err, note)
+	}
+	chunks, err := st.ListTranscript(ctx, "legacy-deleted")
+	if err != nil || len(chunks) != 1 || chunks[0].DeletedAt == nil || chunks[0].DeletionReason != store.DeletionReasonLegacyField {
+		t.Fatalf("legacy imported transcript: chunks=%#v err=%v", chunks, err)
+	}
+	objects, err := st.ListSourceObjects(ctx, "document", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, object := range objects {
+		if object.SourceID == "legacy-deleted" && object.DeletedAt != nil && object.DeletionReason == store.DeletionReasonLegacyField {
+			return
+		}
+	}
+	t.Fatalf("legacy imported source object not tombstoned: %#v", objects)
+}
+
+func openTestStore(t *testing.T, ctx context.Context, name string) *store.Store {
+	t.Helper()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return st
+}
+
+func upsertTestNote(t *testing.T, ctx context.Context, st *store.Store, id, title string, now time.Time) {
+	t.Helper()
+	if err := st.UpsertNote(ctx, model.Note{
+		ID: id, Title: &title, Type: "meeting", CreatedAt: now, UpdatedAt: now,
+		Source: model.SourcePrivateAPI, LastSeenAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/privateapi/normalize.go
+++ b/internal/privateapi/normalize.go
@@ -31,7 +31,7 @@ func NoteFromDocument(doc Document, now time.Time) (model.Note, error) {
 	notesMarkdown := firstStringPtr(doc.NotesMarkdown, textFromJSON(doc.Notes, "markdown", "markdown_text", "md"))
 	summaryText := textFromJSON(doc.Summary, "plain", "text", "content", "summary")
 	summaryMarkdown := textFromJSON(doc.Summary, "markdown", "markdown_text", "md")
-	return model.Note{
+	note := model.Note{
 		ID:              doc.ID,
 		Title:           doc.Title,
 		Type:            noteType,
@@ -47,7 +47,12 @@ func NoteFromDocument(doc Document, now time.Time) (model.Note, error) {
 		Source:          model.SourcePrivateAPI,
 		PayloadHash:     hashutil.JSON(doc),
 		LastSeenAt:      now,
-	}, nil
+	}
+	if deleted != nil {
+		note.DeletionSource = string(model.SourcePrivateAPI)
+		note.DeletionReason = "source-deleted-at"
+	}
+	return note, nil
 }
 
 func TranscriptToModel(chunk TranscriptChunk) (model.TranscriptChunk, error) {
@@ -90,7 +95,7 @@ func PanelToModel(panel Panel) (model.Panel, error) {
 		content = string(panel.Content)
 	}
 	plain := panelText(panel.Content)
-	return model.Panel{
+	modelPanel := model.Panel{
 		ID:           panel.ID,
 		DocumentID:   panel.DocumentID,
 		Title:        panel.Title,
@@ -102,7 +107,17 @@ func PanelToModel(panel Panel) (model.Panel, error) {
 		LastViewedAt: viewed,
 		YdocVersion:  panel.YdocVersion,
 		Source:       model.SourcePrivateAPI,
-	}, nil
+	}
+	deleted, err := timeutil.ParsePtr(panel.DeletedAt)
+	if err != nil {
+		return model.Panel{}, err
+	}
+	if deleted != nil {
+		modelPanel.DeletedAt = deleted
+		modelPanel.DeletionSource = string(model.SourcePrivateAPI)
+		modelPanel.DeletionReason = "source-deleted-at"
+	}
+	return modelPanel, nil
 }
 
 func panelText(raw json.RawMessage) *string {

--- a/internal/store/deletions.go
+++ b/internal/store/deletions.go
@@ -1,0 +1,138 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/openclaw/graincrawl/internal/model"
+)
+
+const (
+	DeletionReasonExplicitFeed = "explicit-delete-feed"
+	DeletionReasonSourceField  = "source-deleted-at"
+	DeletionReasonLegacyField  = "legacy-deleted-at"
+)
+
+type Deletion struct {
+	At     time.Time
+	Source model.Source
+	Reason string
+}
+
+// ReconcileTombstones repairs legacy/imported rows whose note had a deletion
+// timestamp before child provenance columns existed.
+func ReconcileTombstones(ctx context.Context, tx *sql.Tx) error {
+	statements := []string{
+		`UPDATE notes
+SET deletion_source=COALESCE(NULLIF(deletion_source, ''), NULLIF(source, ''), 'unknown'),
+    deletion_reason=COALESCE(NULLIF(deletion_reason, ''), ?)
+WHERE deleted_at IS NOT NULL`,
+		`UPDATE document_panels
+SET deletion_source=COALESCE(NULLIF(deletion_source, ''), NULLIF(source, ''), 'unknown'),
+    deletion_reason=COALESCE(NULLIF(deletion_reason, ''), ?)
+WHERE deleted_at IS NOT NULL`,
+		`UPDATE source_objects
+SET deletion_source=COALESCE(NULLIF(deletion_source, ''), NULLIF(source, ''), 'unknown'),
+    deletion_reason=COALESCE(NULLIF(deletion_reason, ''), ?)
+WHERE deleted_at IS NOT NULL`,
+		`UPDATE transcript_chunks
+SET deleted_at=COALESCE(deleted_at, (SELECT deleted_at FROM notes WHERE notes.id = transcript_chunks.document_id)),
+    deletion_source=COALESCE(NULLIF(deletion_source, ''), (SELECT deletion_source FROM notes WHERE notes.id = transcript_chunks.document_id)),
+    deletion_reason=COALESCE(NULLIF(deletion_reason, ''), (SELECT deletion_reason FROM notes WHERE notes.id = transcript_chunks.document_id))
+WHERE EXISTS (SELECT 1 FROM notes WHERE notes.id = transcript_chunks.document_id AND notes.deleted_at IS NOT NULL)`,
+		`UPDATE document_panels
+SET deleted_at=COALESCE(deleted_at, (SELECT deleted_at FROM notes WHERE notes.id = document_panels.document_id)),
+    deletion_source=COALESCE(NULLIF(deletion_source, ''), (SELECT deletion_source FROM notes WHERE notes.id = document_panels.document_id)),
+    deletion_reason=COALESCE(NULLIF(deletion_reason, ''), (SELECT deletion_reason FROM notes WHERE notes.id = document_panels.document_id))
+WHERE EXISTS (SELECT 1 FROM notes WHERE notes.id = document_panels.document_id AND notes.deleted_at IS NOT NULL)`,
+		`UPDATE source_objects
+SET deleted_at=COALESCE(deleted_at, (SELECT deleted_at FROM notes WHERE notes.id = source_objects.document_id)),
+    deletion_source=COALESCE(NULLIF(deletion_source, ''), (SELECT deletion_source FROM notes WHERE notes.id = source_objects.document_id)),
+    deletion_reason=COALESCE(NULLIF(deletion_reason, ''), (SELECT deletion_reason FROM notes WHERE notes.id = source_objects.document_id))
+WHERE EXISTS (SELECT 1 FROM notes WHERE notes.id = source_objects.document_id AND notes.deleted_at IS NOT NULL)`,
+	}
+	for index, statement := range statements {
+		var args []any
+		if index < 3 {
+			args = []any{DeletionReasonLegacyField}
+		}
+		if _, err := tx.ExecContext(ctx, statement, args...); err != nil {
+			return fmt.Errorf("reconcile tombstones step %d: %w", index+1, err)
+		}
+	}
+	return nil
+}
+
+func (s *Store) TombstoneSourceObject(ctx context.Context, source model.Source, kind, sourceID string, deletion Deletion) error {
+	if sourceID == "" {
+		return nil
+	}
+	if deletion.At.IsZero() {
+		deletion.At = time.Now().UTC()
+	}
+	_, err := s.DB().ExecContext(ctx, `
+UPDATE source_objects
+SET deleted_at=COALESCE(deleted_at, ?),
+    deletion_source=COALESCE(deletion_source, ?),
+    deletion_reason=COALESCE(deletion_reason, ?)
+WHERE source = ? AND kind = ? AND source_id = ?`,
+		deletion.At.UTC().Format(time.RFC3339Nano), string(deletion.Source), deletion.Reason,
+		string(source), kind, sourceID)
+	if err != nil {
+		return fmt.Errorf("tombstone source object %s/%s/%s: %w", source, kind, sourceID, err)
+	}
+	return nil
+}
+
+// TombstoneDocument retains the canonical note and marks every archived child
+// and raw source row for the document. Repeated delete events preserve the
+// first recorded tombstone.
+func (s *Store) TombstoneDocument(ctx context.Context, documentID string, deletion Deletion) error {
+	if documentID == "" {
+		return nil
+	}
+	if deletion.At.IsZero() {
+		deletion.At = time.Now().UTC()
+	}
+	deletedAt := deletion.At.UTC().Format(time.RFC3339Nano)
+	tx, err := s.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tombstone: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO notes (
+  id, type, created_at, updated_at, deleted_at, source, last_seen_at,
+  deletion_source, deletion_reason
+) VALUES (?, 'unknown', ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+  deleted_at=COALESCE(notes.deleted_at, excluded.deleted_at),
+  deletion_source=COALESCE(notes.deletion_source, excluded.deletion_source),
+  deletion_reason=COALESCE(notes.deletion_reason, excluded.deletion_reason)`,
+		documentID, deletedAt, deletedAt, deletedAt, string(deletion.Source), deletedAt,
+		string(deletion.Source), deletion.Reason); err != nil {
+		return fmt.Errorf("tombstone note %s: %w", documentID, err)
+	}
+	for _, table := range []string{"transcript_chunks", "document_panels", "source_objects"} {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+UPDATE %s
+SET deleted_at=COALESCE(deleted_at, ?),
+    deletion_source=COALESCE(deletion_source, ?),
+    deletion_reason=COALESCE(deletion_reason, ?)
+WHERE document_id = ?`, table), deletedAt, string(deletion.Source), deletion.Reason, documentID); err != nil {
+			return fmt.Errorf("tombstone %s for %s: %w", table, documentID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit tombstone: %w", err)
+	}
+	committed = true
+	return nil
+}

--- a/internal/store/notes.go
+++ b/internal/store/notes.go
@@ -13,15 +13,17 @@ func (s *Store) UpsertNote(ctx context.Context, note model.Note) error {
 INSERT INTO notes (
   id, title, type, status, created_at, updated_at, deleted_at, workspace_id,
   calendar_event_id, notes_plain, notes_markdown, summary_text,
-  summary_markdown, source, payload_hash, last_seen_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  summary_markdown, source, payload_hash, last_seen_at, deletion_source, deletion_reason
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
   title=excluded.title,
   type=excluded.type,
   status=excluded.status,
   created_at=excluded.created_at,
   updated_at=excluded.updated_at,
-  deleted_at=excluded.deleted_at,
+  deleted_at=COALESCE(notes.deleted_at, excluded.deleted_at),
+	deletion_source=COALESCE(notes.deletion_source, excluded.deletion_source),
+	deletion_reason=COALESCE(notes.deletion_reason, excluded.deletion_reason),
   workspace_id=excluded.workspace_id,
   calendar_event_id=excluded.calendar_event_id,
   notes_plain=excluded.notes_plain,
@@ -34,7 +36,8 @@ ON CONFLICT(id) DO UPDATE SET
 		note.ID, note.Title, note.Type, note.Status, note.CreatedAt.Format(time.RFC3339Nano),
 		note.UpdatedAt.Format(time.RFC3339Nano), timePtr(note.DeletedAt), note.WorkspaceID,
 		note.CalendarEventID, note.NotesPlain, note.NotesMarkdown, note.SummaryText,
-		note.SummaryMarkdown, string(note.Source), note.PayloadHash, note.LastSeenAt.Format(time.RFC3339Nano))
+		note.SummaryMarkdown, string(note.Source), note.PayloadHash, note.LastSeenAt.Format(time.RFC3339Nano),
+		nullableString(note.DeletionSource), nullableString(note.DeletionReason))
 	return err
 }
 
@@ -45,7 +48,7 @@ func (s *Store) ListNotes(ctx context.Context, limit int) ([]model.Note, error) 
 	rows, err := s.DB().QueryContext(ctx, `
 SELECT id, title, type, status, created_at, updated_at, deleted_at, workspace_id,
   calendar_event_id, notes_plain, notes_markdown, summary_text,
-  summary_markdown, source, payload_hash, last_seen_at
+  summary_markdown, source, payload_hash, last_seen_at, deletion_source, deletion_reason
 FROM notes
 ORDER BY created_at DESC
 LIMIT ?`, limit)
@@ -68,7 +71,7 @@ func (s *Store) GetNote(ctx context.Context, id string) (model.Note, bool, error
 	row := s.DB().QueryRowContext(ctx, `
 SELECT id, title, type, status, created_at, updated_at, deleted_at, workspace_id,
   calendar_event_id, notes_plain, notes_markdown, summary_text,
-  summary_markdown, source, payload_hash, last_seen_at
+  summary_markdown, source, payload_hash, last_seen_at, deletion_source, deletion_reason
 FROM notes
 WHERE id = ?`, id)
 	note, err := scanNote(row)
@@ -87,9 +90,9 @@ type noteScanner interface {
 
 func scanNote(scanner noteScanner) (model.Note, error) {
 	var n model.Note
-	var title, status, deleted, workspace, eventID, plain, markdown, summaryText, summaryMarkdown, source, payloadHash sql.NullString
+	var title, status, deleted, workspace, eventID, plain, markdown, summaryText, summaryMarkdown, source, payloadHash, deletionSource, deletionReason sql.NullString
 	var created, updated, seen string
-	if err := scanner.Scan(&n.ID, &title, &n.Type, &status, &created, &updated, &deleted, &workspace, &eventID, &plain, &markdown, &summaryText, &summaryMarkdown, &source, &payloadHash, &seen); err != nil {
+	if err := scanner.Scan(&n.ID, &title, &n.Type, &status, &created, &updated, &deleted, &workspace, &eventID, &plain, &markdown, &summaryText, &summaryMarkdown, &source, &payloadHash, &seen, &deletionSource, &deletionReason); err != nil {
 		return model.Note{}, err
 	}
 	n.Title = stringPtr(title)
@@ -102,6 +105,8 @@ func scanNote(scanner noteScanner) (model.Note, error) {
 	n.SummaryMarkdown = stringPtr(summaryMarkdown)
 	n.Source = model.Source(source.String)
 	n.PayloadHash = payloadHash.String
+	n.DeletionSource = deletionSource.String
+	n.DeletionReason = deletionReason.String
 	n.CreatedAt, _ = time.Parse(time.RFC3339Nano, created)
 	n.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updated)
 	n.LastSeenAt, _ = time.Parse(time.RFC3339Nano, seen)

--- a/internal/store/panels.go
+++ b/internal/store/panels.go
@@ -13,8 +13,11 @@ func (s *Store) UpsertPanel(ctx context.Context, panel model.Panel) error {
 INSERT INTO document_panels (
   id, document_id, title, template_slug, content_plain, content_markdown,
   content_json, created_at, updated_at, last_viewed_at, ydoc_version,
-  ydoc_cached_at, source
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  ydoc_cached_at, source, deleted_at, deletion_source, deletion_reason
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+  COALESCE(?, (SELECT deleted_at FROM notes WHERE id = ?)),
+  COALESCE(?, (SELECT deletion_source FROM notes WHERE id = ?)),
+  COALESCE(?, (SELECT deletion_reason FROM notes WHERE id = ?)))
 ON CONFLICT(id) DO UPDATE SET
   document_id=excluded.document_id,
   title=excluded.title,
@@ -27,11 +30,17 @@ ON CONFLICT(id) DO UPDATE SET
   last_viewed_at=excluded.last_viewed_at,
   ydoc_version=excluded.ydoc_version,
   ydoc_cached_at=excluded.ydoc_cached_at,
-  source=excluded.source`,
+  source=excluded.source,
+  deleted_at=COALESCE(document_panels.deleted_at, excluded.deleted_at),
+  deletion_source=COALESCE(document_panels.deletion_source, excluded.deletion_source),
+  deletion_reason=COALESCE(document_panels.deletion_reason, excluded.deletion_reason)`,
 		panel.ID, panel.DocumentID, panel.Title, panel.TemplateSlug, panel.ContentPlain,
 		panel.ContentMarkdown, panel.ContentJSON, panel.CreatedAt.Format(time.RFC3339Nano),
 		timePtr(panel.UpdatedAt), timePtr(panel.LastViewedAt), panel.YdocVersion,
-		timePtr(panel.YdocCachedAt), string(panel.Source))
+		timePtr(panel.YdocCachedAt), string(panel.Source),
+		timePtr(panel.DeletedAt), panel.DocumentID,
+		nullableString(panel.DeletionSource), panel.DocumentID,
+		nullableString(panel.DeletionReason), panel.DocumentID)
 	return err
 }
 
@@ -39,7 +48,7 @@ func (s *Store) ListPanels(ctx context.Context, documentID string) ([]model.Pane
 	rows, err := s.DB().QueryContext(ctx, `
 SELECT id, document_id, title, template_slug, content_plain, content_markdown,
   content_json, created_at, updated_at, last_viewed_at, ydoc_version,
-  ydoc_cached_at, source
+  ydoc_cached_at, source, deleted_at, deletion_source, deletion_reason
 FROM document_panels
 WHERE document_id = ?
 ORDER BY created_at DESC`, documentID)
@@ -60,10 +69,10 @@ ORDER BY created_at DESC`, documentID)
 
 func scanPanel(rows *sql.Rows) (model.Panel, error) {
 	var p model.Panel
-	var title, slug, plain, markdown, updated, viewed, cached, source sql.NullString
+	var title, slug, plain, markdown, updated, viewed, cached, source, deleted, deletionSource, deletionReason sql.NullString
 	var ydoc sql.NullInt64
 	var created string
-	if err := rows.Scan(&p.ID, &p.DocumentID, &title, &slug, &plain, &markdown, &p.ContentJSON, &created, &updated, &viewed, &ydoc, &cached, &source); err != nil {
+	if err := rows.Scan(&p.ID, &p.DocumentID, &title, &slug, &plain, &markdown, &p.ContentJSON, &created, &updated, &viewed, &ydoc, &cached, &source, &deleted, &deletionSource, &deletionReason); err != nil {
 		return model.Panel{}, err
 	}
 	p.Title = stringPtr(title)
@@ -75,6 +84,9 @@ func scanPanel(rows *sql.Rows) (model.Panel, error) {
 	p.UpdatedAt = parseNullableTime(updated)
 	p.LastViewedAt = parseNullableTime(viewed)
 	p.YdocCachedAt = parseNullableTime(cached)
+	p.DeletedAt = parseNullableTime(deleted)
+	p.DeletionSource = deletionSource.String
+	p.DeletionReason = deletionReason.String
 	if ydoc.Valid {
 		p.YdocVersion = &ydoc.Int64
 	}

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -1,6 +1,6 @@
 package store
 
-const SchemaVersion = 1
+const SchemaVersion = 2
 
 const Schema = `
 CREATE TABLE IF NOT EXISTS source_objects (
@@ -11,6 +11,9 @@ CREATE TABLE IF NOT EXISTS source_objects (
   payload_json TEXT NOT NULL,
   payload_hash TEXT NOT NULL,
   observed_at TEXT NOT NULL,
+  deleted_at TEXT,
+  deletion_source TEXT,
+  deletion_reason TEXT,
   PRIMARY KEY (source, kind, source_id)
 );
 
@@ -22,6 +25,8 @@ CREATE TABLE IF NOT EXISTS notes (
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   deleted_at TEXT,
+  deletion_source TEXT,
+  deletion_reason TEXT,
   workspace_id TEXT,
   calendar_event_id TEXT,
   notes_plain TEXT,
@@ -42,7 +47,10 @@ CREATE TABLE IF NOT EXISTS transcript_chunks (
   is_final INTEGER NOT NULL,
   transcriber_user_id TEXT,
   text TEXT NOT NULL,
-  payload_hash TEXT
+  payload_hash TEXT,
+  deleted_at TEXT,
+  deletion_source TEXT,
+  deletion_reason TEXT
 );
 
 CREATE TABLE IF NOT EXISTS document_panels (
@@ -58,7 +66,10 @@ CREATE TABLE IF NOT EXISTS document_panels (
   last_viewed_at TEXT,
   ydoc_version INTEGER,
   ydoc_cached_at TEXT,
-  source TEXT NOT NULL
+  source TEXT NOT NULL,
+  deleted_at TEXT,
+  deletion_source TEXT,
+  deletion_reason TEXT
 );
 
 CREATE TABLE IF NOT EXISTS sync_runs (

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -17,7 +17,7 @@ func (s *Store) SearchNotes(ctx context.Context, query string, limit int) ([]mod
 SELECT DISTINCT notes.id, notes.title, notes.type, notes.status, notes.created_at, notes.updated_at,
   notes.deleted_at, notes.workspace_id, notes.calendar_event_id, notes.notes_plain,
   notes.notes_markdown, notes.summary_text, notes.summary_markdown, notes.source,
-  notes.payload_hash, notes.last_seen_at
+  notes.payload_hash, notes.last_seen_at, notes.deletion_source, notes.deletion_reason
 FROM notes
 LEFT JOIN transcript_chunks ON transcript_chunks.document_id = notes.id
 LEFT JOIN document_panels ON document_panels.document_id = notes.id

--- a/internal/store/source_objects.go
+++ b/internal/store/source_objects.go
@@ -9,26 +9,38 @@ import (
 )
 
 type SourceObject struct {
-	Source      model.Source `json:"source"`
-	Kind        string       `json:"kind"`
-	SourceID    string       `json:"source_id"`
-	DocumentID  string       `json:"document_id,omitempty"`
-	PayloadJSON string       `json:"payload_json"`
-	PayloadHash string       `json:"payload_hash"`
-	ObservedAt  time.Time    `json:"observed_at"`
+	Source         model.Source `json:"source"`
+	Kind           string       `json:"kind"`
+	SourceID       string       `json:"source_id"`
+	DocumentID     string       `json:"document_id,omitempty"`
+	PayloadJSON    string       `json:"payload_json"`
+	PayloadHash    string       `json:"payload_hash"`
+	ObservedAt     time.Time    `json:"observed_at"`
+	DeletedAt      *time.Time   `json:"deleted_at,omitempty"`
+	DeletionSource string       `json:"deletion_source,omitempty"`
+	DeletionReason string       `json:"deletion_reason,omitempty"`
 }
 
 func (s *Store) UpsertSourceObject(ctx context.Context, obj SourceObject) error {
 	_, err := s.DB().ExecContext(ctx, `
-INSERT INTO source_objects (source, kind, source_id, document_id, payload_json, payload_hash, observed_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO source_objects (source, kind, source_id, document_id, payload_json, payload_hash, observed_at, deleted_at, deletion_source, deletion_reason)
+VALUES (?, ?, ?, ?, ?, ?, ?,
+  COALESCE(?, (SELECT deleted_at FROM notes WHERE id = ?)),
+  COALESCE(?, (SELECT deletion_source FROM notes WHERE id = ?)),
+  COALESCE(?, (SELECT deletion_reason FROM notes WHERE id = ?)))
 ON CONFLICT(source, kind, source_id) DO UPDATE SET
   document_id=excluded.document_id,
   payload_json=excluded.payload_json,
   payload_hash=excluded.payload_hash,
-  observed_at=excluded.observed_at`,
+  observed_at=excluded.observed_at,
+  deleted_at=COALESCE(source_objects.deleted_at, excluded.deleted_at),
+  deletion_source=COALESCE(source_objects.deletion_source, excluded.deletion_source),
+  deletion_reason=COALESCE(source_objects.deletion_reason, excluded.deletion_reason)`,
 		string(obj.Source), obj.Kind, obj.SourceID, nullableString(obj.DocumentID),
-		obj.PayloadJSON, obj.PayloadHash, obj.ObservedAt.Format(time.RFC3339Nano))
+		obj.PayloadJSON, obj.PayloadHash, obj.ObservedAt.Format(time.RFC3339Nano),
+		timePtr(obj.DeletedAt), obj.DocumentID,
+		nullableString(obj.DeletionSource), obj.DocumentID,
+		nullableString(obj.DeletionReason), obj.DocumentID)
 	return err
 }
 
@@ -44,7 +56,8 @@ func (s *Store) ListSourceObjects(ctx context.Context, kind string, limit int) (
 		limit = 100
 	}
 	rows, err := s.DB().QueryContext(ctx, `
-SELECT source, kind, source_id, COALESCE(document_id, ''), payload_json, payload_hash, observed_at
+SELECT source, kind, source_id, COALESCE(document_id, ''), payload_json, payload_hash, observed_at,
+  deleted_at, deletion_source, deletion_reason
 FROM source_objects
 WHERE (? = '' OR kind = ?)
 ORDER BY observed_at DESC
@@ -71,7 +84,8 @@ type sourceObjectScanner interface {
 func scanSourceObject(scanner sourceObjectScanner) (SourceObject, error) {
 	var obj SourceObject
 	var source, observed string
-	if err := scanner.Scan(&source, &obj.Kind, &obj.SourceID, &obj.DocumentID, &obj.PayloadJSON, &obj.PayloadHash, &observed); err != nil {
+	var deleted, deletionSource, deletionReason sql.NullString
+	if err := scanner.Scan(&source, &obj.Kind, &obj.SourceID, &obj.DocumentID, &obj.PayloadJSON, &obj.PayloadHash, &observed, &deleted, &deletionSource, &deletionReason); err != nil {
 		if err == sql.ErrNoRows {
 			return SourceObject{}, err
 		}
@@ -79,5 +93,8 @@ func scanSourceObject(scanner sourceObjectScanner) (SourceObject, error) {
 	}
 	obj.Source = model.Source(source)
 	obj.ObservedAt, _ = time.Parse(time.RFC3339Nano, observed)
+	obj.DeletedAt = parseNullableTime(deleted)
+	obj.DeletionSource = deletionSource.String
+	obj.DeletionReason = deletionReason.String
 	return obj, nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	ckstore "github.com/openclaw/crawlkit/store"
 )
@@ -13,16 +14,91 @@ type Store struct {
 
 func Open(ctx context.Context, path string) (*Store, error) {
 	inner, err := ckstore.Open(ctx, ckstore.Options{
-		Path:          path,
-		Schema:        Schema,
-		SchemaVersion: SchemaVersion,
-		MaxOpenConns:  1,
-		MaxIdleConns:  1,
+		Path:         path,
+		Schema:       Schema,
+		MaxOpenConns: 1,
+		MaxIdleConns: 1,
 	})
 	if err != nil {
 		return nil, err
 	}
+	current, err := inner.SchemaVersion(ctx)
+	if err != nil {
+		_ = inner.Close()
+		return nil, err
+	}
+	if current > SchemaVersion {
+		_ = inner.Close()
+		return nil, fmt.Errorf("database schema version %d is newer than supported version %d", current, SchemaVersion)
+	}
+	if err := ensureDeletionColumns(ctx, inner.DB()); err != nil {
+		_ = inner.Close()
+		return nil, err
+	}
+	if err := inner.EnsureSchemaVersion(ctx, SchemaVersion); err != nil {
+		_ = inner.Close()
+		return nil, err
+	}
 	return &Store{inner: inner}, nil
+}
+
+func ensureDeletionColumns(ctx context.Context, db *sql.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin deletion migration: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	columns := map[string][]string{
+		"notes": {
+			"deletion_source TEXT",
+			"deletion_reason TEXT",
+		},
+		"transcript_chunks": {
+			"deleted_at TEXT",
+			"deletion_source TEXT",
+			"deletion_reason TEXT",
+		},
+		"document_panels": {
+			"deleted_at TEXT",
+			"deletion_source TEXT",
+			"deletion_reason TEXT",
+		},
+		"source_objects": {
+			"deleted_at TEXT",
+			"deletion_source TEXT",
+			"deletion_reason TEXT",
+		},
+	}
+	for table, definitions := range columns {
+		for _, definition := range definitions {
+			column := definition[:len(definition)-len(" TEXT")]
+			var exists int
+			query := fmt.Sprintf("SELECT count(*) FROM pragma_table_info(%q) WHERE name = ?", table)
+			if err := tx.QueryRowContext(ctx, query, column).Scan(&exists); err != nil {
+				return fmt.Errorf("inspect %s.%s: %w", table, column, err)
+			}
+			if exists != 0 {
+				continue
+			}
+			stmt := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s", ckstore.QuoteIdent(table), definition)
+			if _, err := tx.ExecContext(ctx, stmt); err != nil {
+				return fmt.Errorf("add %s.%s: %w", table, column, err)
+			}
+		}
+	}
+	if err := ReconcileTombstones(ctx, tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit deletion migration: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 func (s *Store) Close() error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -66,5 +68,145 @@ func TestStoreRoundTrip(t *testing.T) {
 	}
 	if len(literalUnderscore) != 0 {
 		t.Fatalf("literal underscore search results: %#v", literalUnderscore)
+	}
+}
+
+func TestOpenMigratesVersionOneDeletionColumns(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "graincrawl-v1.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldSchema := `
+CREATE TABLE source_objects (
+  source TEXT NOT NULL, kind TEXT NOT NULL, source_id TEXT NOT NULL, document_id TEXT,
+  payload_json TEXT NOT NULL, payload_hash TEXT NOT NULL, observed_at TEXT NOT NULL,
+  PRIMARY KEY(source, kind, source_id)
+);
+CREATE TABLE notes (
+  id TEXT PRIMARY KEY, title TEXT, type TEXT NOT NULL, status TEXT, created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL, deleted_at TEXT, workspace_id TEXT, calendar_event_id TEXT,
+  notes_plain TEXT, notes_markdown TEXT, summary_text TEXT, summary_markdown TEXT,
+  source TEXT NOT NULL, payload_hash TEXT, last_seen_at TEXT NOT NULL
+);
+CREATE TABLE transcript_chunks (
+  id TEXT PRIMARY KEY, document_id TEXT NOT NULL, start_timestamp TEXT NOT NULL,
+  end_timestamp TEXT NOT NULL, source TEXT NOT NULL, is_final INTEGER NOT NULL,
+  transcriber_user_id TEXT, text TEXT NOT NULL, payload_hash TEXT
+);
+CREATE TABLE document_panels (
+  id TEXT PRIMARY KEY, document_id TEXT NOT NULL, title TEXT, template_slug TEXT,
+  content_plain TEXT, content_markdown TEXT, content_json TEXT, created_at TEXT NOT NULL,
+  updated_at TEXT, last_viewed_at TEXT, ydoc_version INTEGER, ydoc_cached_at TEXT,
+  source TEXT NOT NULL
+);
+CREATE TABLE schema_migrations(version INTEGER NOT NULL);
+INSERT INTO schema_migrations(version) VALUES(1);
+INSERT INTO notes(id, type, created_at, updated_at, deleted_at, source, last_seen_at)
+VALUES('deleted-doc', 'meeting', '2026-07-15T10:00:00Z', '2026-07-15T11:00:00Z', '2026-07-16T12:00:00Z', 'private-api', '2026-07-15T11:00:00Z');
+INSERT INTO transcript_chunks(id, document_id, start_timestamp, end_timestamp, source, is_final, text)
+VALUES('chunk-1', 'deleted-doc', '2026-07-15T10:00:00Z', '2026-07-15T10:00:01Z', 'mic', 1, 'retained');
+INSERT INTO document_panels(id, document_id, created_at, source)
+VALUES('panel-1', 'deleted-doc', '2026-07-15T10:00:00Z', 'private-api');
+INSERT INTO source_objects(source, kind, source_id, document_id, payload_json, payload_hash, observed_at)
+VALUES('private-api', 'document', 'deleted-doc', 'deleted-doc', '{}', 'hash', '2026-07-15T11:00:00Z');`
+	if _, err := db.ExecContext(ctx, oldSchema); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	for table, columns := range map[string][]string{
+		"notes":             {"deleted_at", "deletion_source", "deletion_reason"},
+		"transcript_chunks": {"deleted_at", "deletion_source", "deletion_reason"},
+		"document_panels":   {"deleted_at", "deletion_source", "deletion_reason"},
+		"source_objects":    {"deleted_at", "deletion_source", "deletion_reason"},
+	} {
+		for _, column := range columns {
+			var count int
+			if err := st.DB().QueryRowContext(ctx, "SELECT count(*) FROM pragma_table_info(?) WHERE name = ?", table, column).Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			if count != 1 {
+				t.Fatalf("missing migrated column %s.%s", table, column)
+			}
+		}
+	}
+	var version int
+	if err := st.DB().QueryRowContext(ctx, "SELECT max(version) FROM schema_migrations").Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != SchemaVersion {
+		t.Fatalf("schema version = %d, want %d", version, SchemaVersion)
+	}
+	for table := range map[string]struct{}{
+		"notes": {}, "transcript_chunks": {}, "document_panels": {}, "source_objects": {},
+	} {
+		where := "id = 'deleted-doc'"
+		switch table {
+		case "transcript_chunks", "document_panels":
+			where = "document_id = 'deleted-doc'"
+		case "source_objects":
+			where = "source_id = 'deleted-doc'"
+		}
+		var count int
+		query := fmt.Sprintf("SELECT count(*) FROM %s WHERE %s AND deleted_at IS NOT NULL AND deletion_source = 'private-api' AND deletion_reason = ?", table, where)
+		if err := st.DB().QueryRowContext(ctx, query, DeletionReasonLegacyField).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Fatalf("legacy tombstone not reconciled in %s", table)
+		}
+	}
+}
+
+func TestChildUpsertsInheritExistingDocumentTombstone(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	if err := st.TombstoneDocument(ctx, "deleted-doc", Deletion{
+		At: now, Source: model.SourcePrivateAPI, Reason: DeletionReasonExplicitFeed,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertTranscriptChunk(ctx, model.TranscriptChunk{
+		ID: "late-chunk", DocumentID: "deleted-doc", StartTimestamp: now,
+		EndTimestamp: now.Add(time.Second), Source: "mic", Text: "retained",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertPanel(ctx, model.Panel{
+		ID: "late-panel", DocumentID: "deleted-doc", CreatedAt: now, Source: model.SourcePrivateAPI,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertSourceObject(ctx, SourceObject{
+		Source: model.SourcePrivateAPI, Kind: "document", SourceID: "late-source",
+		DocumentID: "deleted-doc", PayloadJSON: `{}`, PayloadHash: "hash", ObservedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for table := range map[string]struct{}{
+		"transcript_chunks": {}, "document_panels": {}, "source_objects": {},
+	} {
+		var count int
+		query := fmt.Sprintf("SELECT count(*) FROM %s WHERE document_id = 'deleted-doc' AND deleted_at IS NOT NULL AND deletion_source = 'private-api' AND deletion_reason = ?", table)
+		if err := st.DB().QueryRowContext(ctx, query, DeletionReasonExplicitFeed).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Fatalf("late child did not inherit tombstone in %s", table)
+		}
 	}
 }

--- a/internal/store/transcripts.go
+++ b/internal/store/transcripts.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/openclaw/graincrawl/internal/model"
@@ -11,8 +12,11 @@ func (s *Store) UpsertTranscriptChunk(ctx context.Context, chunk model.Transcrip
 	_, err := s.DB().ExecContext(ctx, `
 INSERT INTO transcript_chunks (
   id, document_id, start_timestamp, end_timestamp, source, is_final,
-  transcriber_user_id, text, payload_hash
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  transcriber_user_id, text, payload_hash, deleted_at, deletion_source, deletion_reason
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
+  COALESCE(?, (SELECT deleted_at FROM notes WHERE id = ?)),
+  COALESCE(?, (SELECT deletion_source FROM notes WHERE id = ?)),
+  COALESCE(?, (SELECT deletion_reason FROM notes WHERE id = ?)))
 ON CONFLICT(id) DO UPDATE SET
   document_id=excluded.document_id,
   start_timestamp=excluded.start_timestamp,
@@ -21,10 +25,16 @@ ON CONFLICT(id) DO UPDATE SET
   is_final=excluded.is_final,
   transcriber_user_id=excluded.transcriber_user_id,
   text=excluded.text,
-  payload_hash=excluded.payload_hash`,
+  payload_hash=excluded.payload_hash,
+  deleted_at=COALESCE(transcript_chunks.deleted_at, excluded.deleted_at),
+  deletion_source=COALESCE(transcript_chunks.deletion_source, excluded.deletion_source),
+  deletion_reason=COALESCE(transcript_chunks.deletion_reason, excluded.deletion_reason)`,
 		chunk.ID, chunk.DocumentID, chunk.StartTimestamp.Format(time.RFC3339Nano),
 		chunk.EndTimestamp.Format(time.RFC3339Nano), chunk.Source, boolInt(chunk.IsFinal),
-		chunk.TranscriberUserID, chunk.Text, chunk.PayloadHash)
+		chunk.TranscriberUserID, chunk.Text, chunk.PayloadHash,
+		timePtr(chunk.DeletedAt), chunk.DocumentID,
+		nullableString(chunk.DeletionSource), chunk.DocumentID,
+		nullableString(chunk.DeletionReason), chunk.DocumentID)
 	return err
 }
 
@@ -32,6 +42,7 @@ func (s *Store) ListTranscript(ctx context.Context, documentID string) ([]model.
 	rows, err := s.DB().QueryContext(ctx, `
 SELECT id, document_id, start_timestamp, end_timestamp, source, is_final,
   transcriber_user_id, text, payload_hash
+  , deleted_at, deletion_source, deletion_reason
 FROM transcript_chunks
 WHERE document_id = ?
 ORDER BY start_timestamp ASC`, documentID)
@@ -43,13 +54,17 @@ ORDER BY start_timestamp ASC`, documentID)
 	for rows.Next() {
 		var chunk model.TranscriptChunk
 		var start, end string
+		var deleted, deletionSource, deletionReason sql.NullString
 		var final int
-		if err := rows.Scan(&chunk.ID, &chunk.DocumentID, &start, &end, &chunk.Source, &final, &chunk.TranscriberUserID, &chunk.Text, &chunk.PayloadHash); err != nil {
+		if err := rows.Scan(&chunk.ID, &chunk.DocumentID, &start, &end, &chunk.Source, &final, &chunk.TranscriberUserID, &chunk.Text, &chunk.PayloadHash, &deleted, &deletionSource, &deletionReason); err != nil {
 			return nil, err
 		}
 		chunk.StartTimestamp, _ = time.Parse(time.RFC3339Nano, start)
 		chunk.EndTimestamp, _ = time.Parse(time.RFC3339Nano, end)
 		chunk.IsFinal = final != 0
+		chunk.DeletedAt = parseNullableTime(deleted)
+		chunk.DeletionSource = deletionSource.String
+		chunk.DeletionReason = deletionReason.String
 		chunks = append(chunks, chunk)
 	}
 	return chunks, rows.Err()

--- a/internal/syncer/desktop_cache.go
+++ b/internal/syncer/desktop_cache.go
@@ -61,6 +61,9 @@ func importDesktopCache(ctx context.Context, st *store.Store, opts Options, file
 			return result, err
 		}
 		note.Source = source
+		if note.DeletedAt != nil {
+			note.DeletionSource = string(source)
+		}
 		if err := st.UpsertNote(ctx, note); err != nil {
 			return result, err
 		}
@@ -80,6 +83,16 @@ func importDesktopCache(ctx context.Context, st *store.Store, opts Options, file
 				}
 				result.Transcripts++
 			}
+		}
+		if note.DeletedAt != nil {
+			if err := st.TombstoneDocument(ctx, doc.ID, store.Deletion{
+				At:     *note.DeletedAt,
+				Source: source,
+				Reason: store.DeletionReasonSourceField,
+			}); err != nil {
+				return result, err
+			}
+			result.Deleted++
 		}
 	}
 	completed := time.Now().UTC()

--- a/internal/syncer/private_api.go
+++ b/internal/syncer/private_api.go
@@ -81,6 +81,7 @@ func syncPrivateWithMessage(ctx context.Context, client privateapi.Client, st *s
 		all = mergeHydratedDocuments(all, hydrated.Docs)
 	}
 	now := time.Now().UTC()
+	deletedDocuments := make(map[string]struct{})
 	for _, doc := range all {
 		if err := retainSourceObject(ctx, st, source, "document", doc.ID, doc.ID, doc, now); err != nil {
 			return result, err
@@ -128,10 +129,47 @@ func syncPrivateWithMessage(ctx context.Context, client privateapi.Client, st *s
 					if err := st.UpsertPanel(ctx, modelPanel); err != nil {
 						return result, err
 					}
+					if modelPanel.DeletedAt != nil {
+						if err := st.TombstoneSourceObject(ctx, source, "panel", panel.ID, store.Deletion{
+							At:     *modelPanel.DeletedAt,
+							Source: source,
+							Reason: store.DeletionReasonSourceField,
+						}); err != nil {
+							return result, err
+						}
+					}
 					result.Panels++
 				}
 			}
 		}
+		if note.DeletedAt != nil {
+			if err := st.TombstoneDocument(ctx, doc.ID, store.Deletion{
+				At:     *note.DeletedAt,
+				Source: source,
+				Reason: store.DeletionReasonSourceField,
+			}); err != nil {
+				return result, err
+			}
+			deletedDocuments[doc.ID] = struct{}{}
+			result.Deleted++
+		}
+	}
+	for _, documentID := range docs.Deleted {
+		if documentID == "" {
+			continue
+		}
+		if _, ok := deletedDocuments[documentID]; ok {
+			continue
+		}
+		if err := st.TombstoneDocument(ctx, documentID, store.Deletion{
+			At:     now,
+			Source: source,
+			Reason: store.DeletionReasonExplicitFeed,
+		}); err != nil {
+			return result, err
+		}
+		deletedDocuments[documentID] = struct{}{}
+		result.Deleted++
 	}
 	completed := time.Now().UTC()
 	_, _ = st.InsertSyncRun(ctx, model.SyncRun{Source: source, StartedAt: started, CompletedAt: completed, Status: "ok", Notes: result.Notes, Transcripts: result.Transcripts, Panels: result.Panels, Message: result.Message})

--- a/internal/syncer/private_api_test.go
+++ b/internal/syncer/private_api_test.go
@@ -2,10 +2,12 @@ package syncer
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/openclaw/graincrawl/internal/model"
 	"github.com/openclaw/graincrawl/internal/privateapi"
@@ -45,6 +47,196 @@ func TestSyncPrivateHydratesDocumentBodyBeforeUpsert(t *testing.T) {
 	}
 	if !ok || note.NotesMarkdown == nil || *note.NotesMarkdown != "hydrated note body" {
 		t.Fatalf("expected hydrated note body, got %#v", note)
+	}
+}
+
+func TestSyncPrivateConsumesExplicitDeleteFeedAndTombstonesChildren(t *testing.T) {
+	ctx := context.Background()
+	deleted := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/get-documents", func(w http.ResponseWriter, r *http.Request) {
+		if deleted {
+			writeJSON(t, w, `{"docs":[],"deleted":["doc-1"],"shared":[]}`)
+			return
+		}
+		writeJSON(t, w, `{"docs":[{"id":"doc-1","title":"Planning","type":"meeting","created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:01:00Z"}],"deleted":[],"shared":[]}`)
+	})
+	mux.HandleFunc("/v1/get-documents-batch", func(w http.ResponseWriter, r *http.Request) {
+		if deleted {
+			writeJSON(t, w, `{"docs":[]}`)
+			return
+		}
+		writeJSON(t, w, `{"docs":[{"id":"doc-1","title":"Planning","type":"meeting","created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:02:00Z"}]}`)
+	})
+	mux.HandleFunc("/v1/get-document-transcript", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `[{"id":"chunk-1","document_id":"doc-1","start_timestamp":"2026-05-06T10:00:00Z","end_timestamp":"2026-05-06T10:00:01Z","source":"mic","is_final":true,"text":"retained transcript"}]`)
+	})
+	mux.HandleFunc("/v1/get-document-panels", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `[{"id":"panel-1","document_id":"doc-1","created_at":"2026-05-06T10:00:00Z","title":"Summary","content":{"text":"retained panel"}}]`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	client := privateapi.Client{BaseURL: srv.URL, AccessToken: "token"}
+	opts := Options{Source: model.SourcePrivateAPI, IncludeTranscripts: true, IncludePanels: true}
+	if _, err := syncPrivateWithMessage(ctx, client, st, opts, false, ""); err != nil {
+		t.Fatal(err)
+	}
+	deleted = true
+	result, err := syncPrivateWithMessage(ctx, client, st, opts, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", result.Deleted)
+	}
+
+	note, ok, err := st.GetNote(ctx, "doc-1")
+	if err != nil || !ok {
+		t.Fatalf("get tombstoned note: ok=%v err=%v", ok, err)
+	}
+	assertDeletion(t, "note", note.DeletedAt, note.DeletionSource, note.DeletionReason)
+	chunks, err := st.ListTranscript(ctx, "doc-1")
+	if err != nil || len(chunks) != 1 {
+		t.Fatalf("transcript chunks = %#v, err=%v", chunks, err)
+	}
+	assertDeletion(t, "transcript", chunks[0].DeletedAt, chunks[0].DeletionSource, chunks[0].DeletionReason)
+	panels, err := st.ListPanels(ctx, "doc-1")
+	if err != nil || len(panels) != 1 {
+		t.Fatalf("panels = %#v, err=%v", panels, err)
+	}
+	assertDeletion(t, "panel", panels[0].DeletedAt, panels[0].DeletionSource, panels[0].DeletionReason)
+	objects, err := st.ListSourceObjects(ctx, "", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objects) != 3 {
+		t.Fatalf("source objects = %d, want 3: %#v", len(objects), objects)
+	}
+	for _, object := range objects {
+		assertDeletion(t, fmt.Sprintf("source object %s", object.Kind), object.DeletedAt, object.DeletionSource, object.DeletionReason)
+	}
+}
+
+func TestSyncPrivateDoesNotDeleteNoteMerelyBecauseItWasNotSeen(t *testing.T) {
+	ctx := context.Background()
+	missing := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/get-documents", func(w http.ResponseWriter, r *http.Request) {
+		if missing {
+			writeJSON(t, w, `{"docs":[],"deleted":[],"shared":[]}`)
+			return
+		}
+		writeJSON(t, w, `{"docs":[{"id":"doc-1","type":"meeting","created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:01:00Z"}],"deleted":[],"shared":[]}`)
+	})
+	mux.HandleFunc("/v1/get-documents-batch", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"docs":[]}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	client := privateapi.Client{BaseURL: srv.URL, AccessToken: "token"}
+	if _, err := syncPrivateWithMessage(ctx, client, st, Options{}, false, ""); err != nil {
+		t.Fatal(err)
+	}
+	missing = true
+	if _, err := syncPrivateWithMessage(ctx, client, st, Options{}, false, ""); err != nil {
+		t.Fatal(err)
+	}
+	note, ok, err := st.GetNote(ctx, "doc-1")
+	if err != nil || !ok {
+		t.Fatalf("get retained note: ok=%v err=%v", ok, err)
+	}
+	if note.DeletedAt != nil || note.DeletionSource != "" || note.DeletionReason != "" {
+		t.Fatalf("not-seen note was tombstoned: %#v", note)
+	}
+}
+
+func TestSyncPrivateRetainsUnknownExplicitDeleteAsStubTombstone(t *testing.T) {
+	ctx := context.Background()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/get-documents", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"docs":[],"deleted":["unknown-doc"],"shared":[]}`)
+	})
+	mux.HandleFunc("/v1/get-documents-batch", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"docs":[]}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	client := privateapi.Client{BaseURL: srv.URL, AccessToken: "token"}
+	if _, err := syncPrivateWithMessage(ctx, client, st, Options{}, false, ""); err != nil {
+		t.Fatal(err)
+	}
+	note, ok, err := st.GetNote(ctx, "unknown-doc")
+	if err != nil || !ok {
+		t.Fatalf("get stub tombstone: ok=%v err=%v", ok, err)
+	}
+	if note.Type != "unknown" {
+		t.Fatalf("stub type = %q, want unknown", note.Type)
+	}
+	assertDeletion(t, "stub note", note.DeletedAt, note.DeletionSource, note.DeletionReason)
+}
+
+func TestSyncPrivateRetainsPanelDeletedAtOnPanelAndSourceObject(t *testing.T) {
+	ctx := context.Background()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/get-documents", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"docs":[{"id":"doc-1","type":"meeting","created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:01:00Z"}],"deleted":[],"shared":[]}`)
+	})
+	mux.HandleFunc("/v1/get-documents-batch", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"docs":[]}`)
+	})
+	mux.HandleFunc("/v1/get-document-panels", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `[{"id":"panel-1","document_id":"doc-1","created_at":"2026-05-06T10:00:00Z","deleted_at":"2026-05-07T11:00:00Z"}]`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	client := privateapi.Client{BaseURL: srv.URL, AccessToken: "token"}
+	if _, err := syncPrivateWithMessage(ctx, client, st, Options{IncludePanels: true}, false, ""); err != nil {
+		t.Fatal(err)
+	}
+	panels, err := st.ListPanels(ctx, "doc-1")
+	if err != nil || len(panels) != 1 {
+		t.Fatalf("panels = %#v err=%v", panels, err)
+	}
+	if panels[0].DeletedAt == nil || panels[0].DeletionReason != store.DeletionReasonSourceField {
+		t.Fatalf("panel deletion = %#v", panels[0])
+	}
+	objects, err := st.ListSourceObjects(ctx, "panel", 10)
+	if err != nil || len(objects) != 1 {
+		t.Fatalf("panel source objects = %#v err=%v", objects, err)
+	}
+	if objects[0].DeletedAt == nil || objects[0].DeletionReason != store.DeletionReasonSourceField {
+		t.Fatalf("panel source deletion = %#v", objects[0])
+	}
+}
+
+func assertDeletion(t *testing.T, label string, deletedAt *time.Time, source, reason string) {
+	t.Helper()
+	if deletedAt == nil || source != string(model.SourcePrivateAPI) || reason != store.DeletionReasonExplicitFeed {
+		t.Fatalf("%s deletion = (%v, %q, %q)", label, deletedAt, source, reason)
 	}
 }
 

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -103,6 +103,55 @@ func TestRunAcceptsEmptyVersion8DesktopCache(t *testing.T) {
 	}
 }
 
+func TestRunDesktopCacheCascadesExplicitDeletedAtTombstone(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{"cache":{"version":8,"state":{"documents":{"doc1":{"id":"doc1","created_at":"2026-05-06T01:00:00Z","updated_at":"2026-05-06T02:00:00Z","deleted_at":"2026-05-07T03:00:00Z","type":"meeting"}},"transcripts":{"doc1":[{"document_id":"doc1","start_timestamp":"2026-05-06T01:00:01Z","end_timestamp":"2026-05-06T01:00:02Z","text":"retained","source":"microphone","id":"c1","is_final":true}]}}}}`
+	if err := os.WriteFile(filepath.Join(profile, "cache-v6.json"), []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{ProfilePath: profile, AllowDesktopCache: true},
+		Sync:    config.SyncConfig{DefaultLimit: 100, IncludeTranscripts: true},
+	}
+	result, err := Run(ctx, cfg, st, Options{Source: model.SourceDesktopCache})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", result.Deleted)
+	}
+	note, ok, err := st.GetNote(ctx, "doc1")
+	if err != nil || !ok || note.DeletedAt == nil {
+		t.Fatalf("note tombstone: ok=%v err=%v note=%#v", ok, err, note)
+	}
+	if note.DeletionSource != string(model.SourceDesktopCache) || note.DeletionReason != store.DeletionReasonSourceField {
+		t.Fatalf("note deletion metadata: %#v", note)
+	}
+	chunks, err := st.ListTranscript(ctx, "doc1")
+	if err != nil || len(chunks) != 1 || chunks[0].DeletedAt == nil {
+		t.Fatalf("transcript tombstone: chunks=%#v err=%v", chunks, err)
+	}
+	objects, err := st.ListSourceObjects(ctx, "", 10)
+	if err != nil || len(objects) != 2 {
+		t.Fatalf("source tombstones: objects=%#v err=%v", objects, err)
+	}
+	for _, object := range objects {
+		if object.DeletedAt == nil || object.DeletionSource != string(model.SourceDesktopCache) {
+			t.Fatalf("source object not tombstoned: %#v", object)
+		}
+	}
+}
+
 func TestRunExplainsEncryptedOnlyDesktopCache(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()

--- a/internal/syncer/types.go
+++ b/internal/syncer/types.go
@@ -21,5 +21,6 @@ type Result struct {
 	Notes       int          `json:"notes"`
 	Transcripts int          `json:"transcripts"`
 	Panels      int          `json:"panels"`
+	Deleted     int          `json:"deleted"`
 	Message     string       `json:"message,omitempty"`
 }


### PR DESCRIPTION
## Summary

- consume the private API `Deleted []string` feed and retain stable note tombstones with deletion source/reason
- cascade note deletion state to transcripts, panels, and raw source objects; migrate and reconcile legacy tombstones
- make portable snapshot imports destination-preserving merges by default, with exact replacement only through `--replace`
- document the import contract and add a curated changelog entry

`VISION.md` does not exist in this repository, so there was no vision file to update.

## Regression coverage

- explicit private API delete feed tombstones notes and all retained children/source rows
- missing-from-sync does not tombstone a note
- unknown explicitly deleted IDs become stable stub tombstones
- late child upserts inherit an existing parent tombstone
- v1 databases migrate deletion provenance and child state
- legacy snapshot tombstones reconcile during both merge and replace imports
- merge retains destination-only rows and conflicting local payloads; `--replace` removes them
- desktop-cache `deleted_at` cascades through retained children/source rows

## Proof

- `make check`
- `make smoke`
- `deadcode -test ./...`
- `git diff --check`
- autoreview: `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings

Real binaries, same portable fixture:

| binary / mode | destination-only rows after import |
| --- | ---: |
| `origin/main`, default legacy import | 0 |
| this branch, default `merge` | 1 |
| this branch, explicit `--replace` | 0 |

Real binary deletion fixture:

| behavior | `origin/main` | this branch |
| --- | ---: | ---: |
| note tombstone | 1 | 1 |
| transcript tombstone | unavailable (no child deletion columns) | 1 |
| raw source-object tombstones | unavailable | 2 |
| sync result deletion count | unavailable | 1 |

Source-blind behavior validation also confirmed persisted merge output, local conflict preservation, exact replace behavior, note/transcript/source tombstone queries, and non-zero errors for missing paths and unknown import flags.
