### PR TITLE
fix: fail closed with an honest diagnostic when Granola migrates its DEK to the app-scoped Keychain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Detect Granola 7.427+'s app-scoped Keychain migration, fail local sync and unlock with honest diagnostics, and return a nonzero status instead of silently importing nothing. Thanks @nwoonet.
+
 ## v0.3.3 - 2026-07-18
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ browser over the archived SQLite data.
 - export notes to Markdown
 - browse archived notes with the shared crawlkit TUI
 - create/import portable crawlkit snapshots
-- explicitly unlock encrypted JSON for in-memory cache import or private API
-  authentication; keep OPFS unsupported
+- explicitly unlock legacy encrypted JSON when `storage.dek` is still present;
+  keep OPFS unsupported
 
 ## Install
 
@@ -134,3 +134,18 @@ to Granola. OPFS remains unsupported. Ordinary `doctor`, `status`, `notes`,
 `export`, and `tui` commands never prompt Keychain.
 
 See [docs/security.md](docs/security.md).
+
+### Granola 7.427+ encrypted state
+
+Granola 7.427+ moved its data-encryption key into the macOS data-protection
+Keychain under the app-scoped access group `QZ7DHHLN25.granola`. Only code
+signed by Granola's team can read that item, so graincrawl cannot decrypt the
+local Granola state after this migration. In this state `unlock encrypted-json`
+is always blocked, and `private-api` or `desktop-cache` is blocked only when the
+state that source itself needs is encrypted — a source whose plaintext file is
+still readable keeps working. Existing data already archived by graincrawl
+remains readable.
+
+`graincrawl doctor` detects the migration from the profile state: `storage.dek`
+is absent while at least one `*.enc` file is present. This is an upstream
+Keychain access boundary, not a graincrawl bug.

--- a/docs/security.md
+++ b/docs/security.md
@@ -19,11 +19,11 @@ enables encrypted sources and invokes an explicit unlock command.
 
 ## Keychain Boundary
 
-Encrypted JSON support runs only inside the authorized public command path.
-After configuration and explicit-unlock checks, graincrawl snapshots the
-requested encrypted files into memory, reads the `Granola Safe Storage`
-Keychain item through `/usr/bin/security`, unwraps the DEK, and decrypts only
-the requested JSON. Keychain access has a 30-second timeout. The DEK, Keychain
+Legacy encrypted JSON support runs only inside the authorized public command
+path. When `storage.dek` is still present, graincrawl snapshots the requested
+encrypted files into memory, reads the legacy `Granola Safe Storage` Keychain
+item through `/usr/bin/security`, unwraps the DEK, and decrypts only the
+requested JSON. Keychain access has a 30-second timeout. The DEK, Keychain
 secret, and decrypted Granola JSON are never written to disk. There is no
 hidden helper command that can bypass the public authorization checks. OPFS
 remains unsupported.
@@ -31,6 +31,22 @@ remains unsupported.
 `allow_encrypted_json = true` permits the feature, but never invokes it by
 itself. The operator must also run `graincrawl unlock encrypted-json` or pass
 `--unlock encrypted-json` to `sync`.
+
+## Granola 7.427+ encrypted state
+
+Granola 7.427+ moved its data-encryption key into the macOS data-protection
+Keychain under the app-scoped access group `QZ7DHHLN25.granola`. Only
+Granola-signed code can read that item. When `storage.dek` is absent and the
+Granola profile contains at least one `*.enc` file, graincrawl diagnoses this
+post-migration state without attempting to access the new Keychain item.
+`unlock encrypted-json` is blocked outright; `private-api` and `desktop-cache`
+are blocked per source, only when the file that source reads (`supabase.json`
+and `cache-v6.json` respectively) is the encrypted one, so a source with usable
+plaintext state is neither blocked nor advertised as unavailable.
+
+This is an upstream code-signing and Keychain access-group boundary, not a
+graincrawl bug. The legacy unlock path remains available only for profiles that
+still contain `storage.dek`; existing graincrawl archives remain readable.
 
 ## Operational Rules
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -203,6 +203,7 @@ func (a App) runDoctor(ctx context.Context, w io.Writer, flags GlobalFlags) erro
 	output.PrintKV(w, "granola_version", report.GranolaApp.Version)
 	output.PrintKV(w, "cache_v6", report.Files.CacheV6.Exists)
 	output.PrintKV(w, "supabase", report.Files.Supabase.Exists)
+	output.PrintKV(w, "post_migration_state", report.Unlock.PostMigrationState)
 	for _, diagnostic := range report.Diagnostics {
 		output.PrintKV(w, "diagnostic", diagnostic.Message)
 	}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/openclaw/graincrawl/internal/config"
+	"github.com/openclaw/graincrawl/internal/granola"
 	"github.com/openclaw/graincrawl/internal/model"
 	"github.com/openclaw/graincrawl/internal/store"
 )
@@ -124,6 +125,117 @@ func TestAppReportsEncryptedOnlyGranolaState(t *testing.T) {
 	}
 	if !strings.Contains(unlockOut.String(), "disabled") || strings.Contains(unlockOut.String(), "keychain_accessed") {
 		t.Fatalf("unlock status should remain prompt-free when disabled:\n%s", unlockOut.String())
+	}
+}
+
+func TestAppBlocksPostMigrationGranolaState(t *testing.T) {
+	cfgPath := writeTestConfig(t)
+	cfg, _, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Granola.AllowEncryptedJSON = true
+	cfg.Security.KeychainPromptMode = "explicit"
+	if err := config.Save(cfgPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cfg.Granola.ProfilePath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"cache-v6.json.enc", "supabase.json.enc"} {
+		if err := os.WriteFile(filepath.Join(cfg.Granola.ProfilePath, name), []byte("encrypted"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	decryptCalls := 0
+	app := App{
+		DecryptEncryptedJSON: func(context.Context, string, ...string) (map[string]json.RawMessage, error) {
+			decryptCalls++
+			return nil, nil
+		},
+	}
+
+	for _, command := range [][]string{
+		{"--json", "--config", cfgPath, "doctor"},
+		{"--config", cfgPath, "doctor"},
+		{"--json", "--config", cfgPath, "unlock"},
+		{"--config", cfgPath, "unlock"},
+	} {
+		var out bytes.Buffer
+		app.Stdout = &out
+		if err := app.Run(context.Background(), command); err != nil {
+			t.Fatalf("%v failed: %v", command, err)
+		}
+		if !strings.Contains(out.String(), granola.PostMigrationStateMessage) {
+			t.Fatalf("%v output missing migration diagnostic:\n%s", command, out.String())
+		}
+		for _, forbidden := range []string{"explicit encrypted-json unlock", "current plaintext source"} {
+			if strings.Contains(out.String(), forbidden) {
+				t.Fatalf("%v output contains dead-end advice %q:\n%s", command, forbidden, out.String())
+			}
+		}
+	}
+
+	var sourcesOut bytes.Buffer
+	app.Stdout = &sourcesOut
+	if err := app.Run(context.Background(), []string{"--json", "--config", cfgPath, "sources"}); err != nil {
+		t.Fatal(err)
+	}
+	var response struct {
+		Result struct {
+			Sources []struct {
+				Source  model.Source `json:"source"`
+				Allowed bool         `json:"allowed"`
+				Notes   string       `json:"notes"`
+			} `json:"sources"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(sourcesOut.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	blocked := map[model.Source]bool{
+		model.SourcePrivateAPI:   false,
+		model.SourceDesktopCache: false,
+	}
+	for _, source := range response.Result.Sources {
+		if _, ok := blocked[source.Source]; !ok {
+			continue
+		}
+		if source.Allowed || source.Notes != granola.PostMigrationStateMessage {
+			t.Fatalf("source support = %#v", source)
+		}
+		blocked[source.Source] = true
+	}
+	for source, seen := range blocked {
+		if !seen {
+			t.Fatalf("sources output did not include blocked %s: %s", source, sourcesOut.String())
+		}
+	}
+
+	for _, command := range [][]string{
+		{"--config", cfgPath, "sync", "--source", "private-api"},
+		{"--config", cfgPath, "sync", "--source", "private-api", "--unlock", "encrypted-json"},
+		{"--config", cfgPath, "sync", "--source", "desktop-cache"},
+		{"--config", cfgPath, "sync", "--source", "desktop-cache", "--unlock", "encrypted-json"},
+		{"--config", cfgPath, "unlock", "encrypted-json"},
+	} {
+		var out bytes.Buffer
+		app.Stdout = &out
+		err := app.Run(context.Background(), command)
+		if err == nil {
+			t.Fatalf("%v succeeded; want nonzero command error", command)
+		}
+		if !strings.Contains(err.Error(), granola.PostMigrationStateMessage) {
+			t.Fatalf("%v error missing migration diagnostic: %v", command, err)
+		}
+		for _, forbidden := range []string{"explicit encrypted-json unlock", "current plaintext source"} {
+			if strings.Contains(err.Error(), forbidden) {
+				t.Fatalf("%v error contains dead-end advice %q: %v", command, forbidden, err)
+			}
+		}
+	}
+	if decryptCalls != 0 {
+		t.Fatalf("post-migration commands invoked decryptor %d times", decryptCalls)
 	}
 }
 

--- a/internal/cli/security.go
+++ b/internal/cli/security.go
@@ -22,7 +22,8 @@ func (a App) runSources(ctx context.Context, w io.Writer, flags GlobalFlags) err
 		return err
 	}
 	defer rt.Close()
-	sources := security.Sources(rt.Config)
+	paths := granola.Paths(rt.Config.Granola.ProfilePath, rt.Config.Granola.AppPath)
+	sources := security.Sources(rt.Config, paths)
 	if flags.JSON {
 		return output.WriteEnvelope(w, map[string]any{"sources": sources})
 	}
@@ -52,7 +53,8 @@ func (a App) runUnlock(ctx context.Context, w io.Writer, flags GlobalFlags, args
 		}
 		return a.runEncryptedJSONUnlock(ctx, w, flags, rt.Config)
 	}
-	report := security.Unlock(rt.Config)
+	paths := granola.Paths(rt.Config.Granola.ProfilePath, rt.Config.Granola.AppPath)
+	report := security.Unlock(rt.Config, granola.PostMigrationState(paths))
 	if flags.JSON {
 		return output.WriteEnvelope(w, report)
 	}
@@ -64,13 +66,16 @@ func (a App) runUnlock(ctx context.Context, w io.Writer, flags GlobalFlags, args
 }
 
 func (a App) runEncryptedJSONUnlock(ctx context.Context, w io.Writer, flags GlobalFlags, cfg config.Config) error {
+	paths := granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath)
+	if granola.PostMigrationState(paths) {
+		return fmt.Errorf("encrypted-json unlock is blocked: %s", granola.PostMigrationStateMessage)
+	}
 	if !cfg.Granola.AllowEncryptedJSON {
 		return fmt.Errorf("encrypted-json source disabled in config")
 	}
 	if !security.PromptAllowed(cfg.Security.KeychainPromptMode) {
 		return fmt.Errorf("keychain prompt mode %q blocks encrypted-json unlock", cfg.Security.KeychainPromptMode)
 	}
-	paths := granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath)
 	names := make([]string, 0, 2)
 	if _, err := os.Stat(paths.CacheV6Encrypted); err == nil {
 		names = append(names, encryptedjson.CacheFile)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -32,6 +32,7 @@ type FileReport struct {
 
 type UnlockReport struct {
 	EncryptedJSONRequired bool `json:"encrypted_json_required"`
+	PostMigrationState    bool `json:"post_migration_state"`
 	OPFSPresent           bool `json:"opfs_present"`
 	KeychainMayPrompt     bool `json:"keychain_may_prompt"`
 }
@@ -65,9 +66,16 @@ func Run(cfg config.Config, configPath string, now time.Time) Report {
 		report.Token = &summary
 	}
 	report.Unlock.EncryptedJSONRequired = granola.EncryptedNewer(paths.CacheV6, paths.CacheV6Encrypted) || granola.EncryptedNewer(paths.Supabase, paths.SupabaseEncrypted)
+	report.Unlock.PostMigrationState = granola.PostMigrationState(paths)
 	report.Unlock.OPFSPresent = report.Files.IndexedDB.Exists && report.Files.FileSystem.Exists
 	report.Unlock.KeychainMayPrompt = false
-	if granola.EncryptedOnlyState(paths) {
+	if report.Unlock.PostMigrationState {
+		report.Diagnostics = append(report.Diagnostics, Diagnostic{
+			Code:     "granola_dek_keychain_migration",
+			Severity: "error",
+			Message:  granola.PostMigrationDiagnostic(report.GranolaApp.Version),
+		})
+	} else if granola.EncryptedOnlyState(paths) {
 		report.Diagnostics = append(report.Diagnostics, Diagnostic{
 			Code:     "granola_encrypted_only_state",
 			Severity: "warning",

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -48,6 +48,43 @@ func TestRunReportsEncryptedOnlyGranolaState(t *testing.T) {
 	}
 }
 
+func TestRunReportsPostMigrationStateWithGranolaVersion(t *testing.T) {
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	appPath := filepath.Join(root, "Granola.app")
+	if err := os.MkdirAll(filepath.Join(appPath, "Contents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	plist := `<?xml version="1.0"?><plist><dict><key>CFBundleShortVersionString</key><string>7.441.6</string><key>CFBundleIdentifier</key><string>com.granola.app</string></dict></plist>`
+	if err := os.WriteFile(filepath.Join(appPath, "Contents", "Info.plist"), []byte(plist), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "stored-accounts.json.enc"), []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	report := Run(config.Config{
+		Granola: config.GranolaConfig{ProfilePath: profile, AppPath: appPath},
+	}, "/tmp/graincrawl.toml", time.Now())
+	if !report.Unlock.PostMigrationState {
+		t.Fatal("expected post-migration state")
+	}
+	if len(report.Diagnostics) != 1 {
+		t.Fatalf("expected one diagnostic, got %#v", report.Diagnostics)
+	}
+	diagnostic := report.Diagnostics[0]
+	if diagnostic.Code != "granola_dek_keychain_migration" || diagnostic.Severity != "error" {
+		t.Fatalf("unexpected diagnostic metadata: %#v", diagnostic)
+	}
+	want := granola.PostMigrationStateMessage + " Detected Granola version 7.441.6."
+	if diagnostic.Message != want {
+		t.Fatalf("diagnostic = %q, want %q", diagnostic.Message, want)
+	}
+}
+
 func TestRunReportsEncryptedOnlyCacheState(t *testing.T) {
 	profile := filepath.Join(t.TempDir(), "Granola")
 	if err := os.MkdirAll(profile, 0o700); err != nil {

--- a/internal/granola/files.go
+++ b/internal/granola/files.go
@@ -1,8 +1,16 @@
 package granola
 
-import "os"
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/openclaw/graincrawl/internal/model"
+)
 
 const EncryptedOnlyStateMessage = "Granola desktop state is encrypted-only; rerun with explicit encrypted-json unlock enabled to read newer cache-v6.json.enc or supabase.json.enc, or use a current plaintext source."
+
+const PostMigrationStateMessage = "Granola 7.427+ moved its data-encryption key into the macOS data-protection Keychain under the app-scoped access group QZ7DHHLN25.granola; only Granola-signed code can read it, so graincrawl cannot decrypt local Granola state on these versions."
 
 type FileState struct {
 	Path    string `json:"path"`
@@ -37,6 +45,62 @@ func EncryptedNewer(plain, encrypted string) bool {
 
 func EncryptedOnlyState(paths ProfilePaths) bool {
 	return EncryptedCacheState(paths) || EncryptedSupabaseState(paths)
+}
+
+func PostMigrationState(paths ProfilePaths) bool {
+	if _, err := os.Stat(paths.StorageDEK); !os.IsNotExist(err) {
+		return false
+	}
+	entries, err := os.ReadDir(paths.Root)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".enc") {
+			return true
+		}
+	}
+	return false
+}
+
+// PlaintextSourceStateUsable reports whether the plaintext file a source reads
+// actually exists and is not superseded by an encrypted copy. Absence of an
+// encrypted file alone does not make a source usable.
+func PlaintextSourceStateUsable(paths ProfilePaths, source model.Source) bool {
+	var path string
+	switch source {
+	case model.SourcePrivateAPI:
+		path = paths.Supabase
+	case model.SourceDesktopCache:
+		path = paths.CacheV6
+	default:
+		return false
+	}
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	return !SourceStateEncrypted(paths, source)
+}
+
+// SourceStateEncrypted reports whether the local state a source needs is
+// encrypted. private-api reads supabase.json, desktop-cache reads cache-v6.json;
+// an encrypted file belonging to the other source must not block this one.
+func SourceStateEncrypted(paths ProfilePaths, source model.Source) bool {
+	switch source {
+	case model.SourcePrivateAPI:
+		return EncryptedSupabaseState(paths)
+	case model.SourceDesktopCache:
+		return EncryptedCacheState(paths)
+	default:
+		return EncryptedOnlyState(paths)
+	}
+}
+
+func PostMigrationDiagnostic(version string) string {
+	if version == "" {
+		return PostMigrationStateMessage
+	}
+	return fmt.Sprintf("%s Detected Granola version %s.", PostMigrationStateMessage, version)
 }
 
 func EncryptedCacheState(paths ProfilePaths) bool {

--- a/internal/granola/files_test.go
+++ b/internal/granola/files_test.go
@@ -1,0 +1,65 @@
+package granola
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPostMigrationState(t *testing.T) {
+	tests := []struct {
+		name          string
+		createProfile bool
+		files         []string
+		want          bool
+	}{
+		{
+			name:          "migrated",
+			createProfile: true,
+			files:         []string{"cache-v6.json.enc"},
+			want:          true,
+		},
+		{
+			name:          "legacy",
+			createProfile: true,
+			files:         []string{"cache-v6.json.enc", "storage.dek"},
+			want:          false,
+		},
+		{
+			name:          "plaintext only",
+			createProfile: true,
+			files:         []string{"cache-v6.json"},
+			want:          false,
+		},
+		{
+			name: "no profile",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile := filepath.Join(t.TempDir(), "Granola")
+			if tt.createProfile {
+				if err := os.MkdirAll(profile, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for _, name := range tt.files {
+				if err := os.WriteFile(filepath.Join(profile, name), []byte("fixture"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := PostMigrationState(Paths(profile, "")); got != tt.want {
+				t.Fatalf("PostMigrationState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPostMigrationDiagnosticIncludesVersionWhenAvailable(t *testing.T) {
+	got := PostMigrationDiagnostic("7.441.6")
+	want := PostMigrationStateMessage + " Detected Granola version 7.441.6."
+	if got != want {
+		t.Fatalf("PostMigrationDiagnostic() = %q, want %q", got, want)
+	}
+}

--- a/internal/security/report.go
+++ b/internal/security/report.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"github.com/openclaw/graincrawl/internal/config"
+	"github.com/openclaw/graincrawl/internal/granola"
 	"github.com/openclaw/graincrawl/internal/model"
 )
 
@@ -31,8 +32,9 @@ type SecretReport struct {
 	Message            string `json:"message"`
 }
 
-func Sources(cfg config.Config) []SourceSupport {
-	return []SourceSupport{
+func Sources(cfg config.Config, paths granola.ProfilePaths) []SourceSupport {
+	postMigration := granola.PostMigrationState(paths)
+	sources := []SourceSupport{
 		{
 			Source:      model.SourcePrivateAPI,
 			Allowed:     cfg.Granola.AllowPrivateAPI,
@@ -69,18 +71,42 @@ func Sources(cfg config.Config) []SourceSupport {
 			Notes:       "official API is currently limited compared with local archive goals",
 		},
 	}
+	if postMigration {
+		for i := range sources {
+			switch sources[i].Source {
+			case model.SourcePrivateAPI, model.SourceDesktopCache:
+				// Match sync: only the source whose own state is encrypted is
+				// blocked, so advertised support cannot contradict behavior.
+				if !granola.SourceStateEncrypted(paths, sources[i].Source) {
+					continue
+				}
+				sources[i].Allowed = false
+				sources[i].Notes = granola.PostMigrationStateMessage
+			case model.SourceEncryptedJSON:
+				sources[i].Allowed = false
+				sources[i].Notes = granola.PostMigrationStateMessage
+			}
+		}
+	}
+	return sources
 }
 
-func Unlock(cfg config.Config) UnlockReport {
+func Unlock(cfg config.Config, postMigration bool) UnlockReport {
 	mode := cfg.Security.KeychainPromptMode
+	promptAllowed := PromptAllowed(mode)
+	message := unlockMessage(cfg.Granola.AllowEncryptedJSON, cfg.Granola.AllowOPFS, mode)
+	if postMigration {
+		promptAllowed = false
+		message = granola.PostMigrationStateMessage
+	}
 	return UnlockReport{
 		KeychainPromptMode: mode,
 		PersistHelperKeys:  cfg.Security.PersistHelperKeys,
 		EncryptedJSON:      cfg.Granola.AllowEncryptedJSON,
 		OPFS:               cfg.Granola.AllowOPFS,
 		RequiresCompanion:  false,
-		PromptAllowed:      PromptAllowed(mode),
-		Message:            unlockMessage(cfg.Granola.AllowEncryptedJSON, cfg.Granola.AllowOPFS, mode),
+		PromptAllowed:      promptAllowed,
+		Message:            message,
 	}
 }
 

--- a/internal/security/report_test.go
+++ b/internal/security/report_test.go
@@ -1,10 +1,13 @@
 package security
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/openclaw/graincrawl/internal/config"
+	"github.com/openclaw/graincrawl/internal/granola"
 )
 
 func TestUnlockReportDoesNotRequireCompanion(t *testing.T) {
@@ -12,7 +15,7 @@ func TestUnlockReportDoesNotRequireCompanion(t *testing.T) {
 		Granola:  config.GranolaConfig{AllowEncryptedJSON: true},
 		Security: config.SecurityConfig{KeychainPromptMode: "explicit"},
 	}
-	report := Unlock(cfg)
+	report := Unlock(cfg, false)
 	if report.RequiresCompanion {
 		t.Fatal("in-process encrypted JSON unlock must not require a companion")
 	}
@@ -22,11 +25,64 @@ func TestUnlockReportDoesNotRequireCompanion(t *testing.T) {
 }
 
 func TestUnlockReportExplainsUnsupportedOPFSWithoutCompanion(t *testing.T) {
-	report := Unlock(config.Config{Granola: config.GranolaConfig{AllowOPFS: true}})
+	report := Unlock(config.Config{Granola: config.GranolaConfig{AllowOPFS: true}}, false)
 	if report.RequiresCompanion {
 		t.Fatal("unsupported OPFS must not claim a running companion requirement")
 	}
 	if !strings.Contains(report.Message, "unsupported") || !strings.Contains(report.Message, "no companion") {
 		t.Fatalf("unexpected OPFS unlock report: %#v", report)
+	}
+}
+
+func TestMigratedProfileBlocksLocalSourcesAndUnlock(t *testing.T) {
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			AllowPrivateAPI:    true,
+			AllowDesktopCache:  true,
+			AllowEncryptedJSON: true,
+		},
+		Security: config.SecurityConfig{KeychainPromptMode: "explicit"},
+	}
+	profile := t.TempDir()
+	for _, name := range []string{"cache-v6.json.enc", "supabase.json.enc"} {
+		if err := os.WriteFile(filepath.Join(profile, name), []byte("encrypted"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	paths := granola.Paths(profile, "")
+	for _, source := range Sources(cfg, paths) {
+		switch source.Source {
+		case "private-api", "desktop-cache", "encrypted-json":
+			if source.Allowed || source.Notes != granola.PostMigrationStateMessage {
+				t.Fatalf("migrated source support = %#v", source)
+			}
+		}
+	}
+
+	// A migrated profile whose plaintext cache is still usable must keep
+	// desktop-cache advertised, matching sync behavior.
+	mixed := t.TempDir()
+	if err := os.WriteFile(filepath.Join(mixed, "supabase.json.enc"), []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mixed, "cache-v6.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, source := range Sources(cfg, granola.Paths(mixed, "")) {
+		switch source.Source {
+		case "desktop-cache":
+			if !source.Allowed {
+				t.Fatalf("usable plaintext cache reported unavailable: %#v", source)
+			}
+		case "private-api":
+			if source.Allowed {
+				t.Fatalf("encrypted supabase state should block private-api: %#v", source)
+			}
+		}
+	}
+
+	report := Unlock(cfg, true)
+	if report.PromptAllowed || report.Message != granola.PostMigrationStateMessage {
+		t.Fatalf("migrated unlock report = %#v", report)
 	}
 }

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -14,10 +14,6 @@ import (
 )
 
 func Run(ctx context.Context, cfg config.Config, st *store.Store, opts Options) (Result, error) {
-	decrypt, err := encryptedJSONDecryptor(cfg, opts)
-	if err != nil {
-		return Result{}, err
-	}
 	sourceExplicit := opts.Source != ""
 	if opts.Source == "" {
 		opts.Source = model.Source(cfg.Granola.PreferredSource)
@@ -27,12 +23,38 @@ func Run(ctx context.Context, cfg config.Config, st *store.Store, opts Options) 
 	}
 	opts.IncludeTranscripts = !opts.SkipTranscripts && (opts.IncludeTranscripts || cfg.Sync.IncludeTranscripts)
 	opts.IncludePanels = !opts.SkipPanels && (opts.IncludePanels || cfg.Sync.IncludePanels)
+	paths := granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath)
 	switch opts.Source {
 	case model.SourcePrivateAPI:
 		if !cfg.Granola.AllowPrivateAPI {
 			return Result{}, fmt.Errorf("private-api source disabled in config")
 		}
-		encryptedSupabase := granola.EncryptedSupabaseState(granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath))
+	case model.SourceDesktopCache:
+		if !cfg.Granola.AllowDesktopCache {
+			return Result{}, fmt.Errorf("desktop-cache source disabled in config")
+		}
+	default:
+		return Result{}, fmt.Errorf("source %q is disabled or unsupported in this build", opts.Source)
+	}
+	// Block only the source whose own state is encrypted: an unrelated .enc
+	// file must not hide plaintext this source can still read, and an implicit
+	// private-api request still falls back to a readable desktop cache.
+	if granola.PostMigrationState(paths) && granola.SourceStateEncrypted(paths, opts.Source) {
+		fallback := opts.Source == model.SourcePrivateAPI && !sourceExplicit &&
+			cfg.Granola.AllowDesktopCache && granola.PlaintextSourceStateUsable(paths, model.SourceDesktopCache)
+		if !fallback {
+			result := Result{Source: opts.Source, Message: granola.PostMigrationStateMessage}
+			return result, fmt.Errorf("%s source is blocked: %s", opts.Source, granola.PostMigrationStateMessage)
+		}
+		opts.Source = model.SourceDesktopCache
+	}
+	decrypt, err := encryptedJSONDecryptor(cfg, opts)
+	if err != nil {
+		return Result{}, err
+	}
+	switch opts.Source {
+	case model.SourcePrivateAPI:
+		encryptedSupabase := granola.EncryptedSupabaseState(paths)
 		if encryptedSupabase && decrypt == nil && !sourceExplicit && cfg.Granola.AllowDesktopCache {
 			opts.Source = model.SourceDesktopCache
 			return runDesktopCache(ctx, cfg, st, opts, decrypt)
@@ -41,7 +63,6 @@ func Run(ctx context.Context, cfg config.Config, st *store.Store, opts Options) 
 			if decrypt == nil {
 				return Result{Source: model.SourcePrivateAPI, Message: granola.EncryptedOnlyStateMessage}, fmt.Errorf("private-api source requires plaintext supabase.json: %s", granola.EncryptedOnlyStateMessage)
 			}
-			paths := granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath)
 			names := []string{encryptedjson.SupabaseFile}
 			encryptedCacheFallback := !sourceExplicit && cfg.Granola.AllowDesktopCache && granola.EncryptedCacheState(paths)
 			if encryptedCacheFallback {
@@ -78,9 +99,8 @@ func Run(ctx context.Context, cfg config.Config, st *store.Store, opts Options) 
 		return result, err
 	case model.SourceDesktopCache:
 		return runDesktopCache(ctx, cfg, st, opts, decrypt)
-	default:
-		return Result{}, fmt.Errorf("source %q is disabled or unsupported in this build", opts.Source)
 	}
+	return Result{}, fmt.Errorf("source %q is disabled or unsupported in this build", opts.Source)
 }
 
 func runDesktopCache(ctx context.Context, cfg config.Config, st *store.Store, opts Options, decrypt encryptedjson.DecryptFunc) (Result, error) {

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openclaw/graincrawl/internal/config"
 	"github.com/openclaw/graincrawl/internal/encryptedjson"
+	"github.com/openclaw/graincrawl/internal/granola"
 	"github.com/openclaw/graincrawl/internal/model"
 	"github.com/openclaw/graincrawl/internal/store"
 )
@@ -258,6 +259,9 @@ func TestRunRejectsNewerEncryptedDesktopCache(t *testing.T) {
 	if err := os.WriteFile(cacheEncPath, []byte("encrypted"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(profile, "storage.dek"), []byte("wrapped"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	makeNewer(t, cachePath, cacheEncPath)
 	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
 	if err != nil {
@@ -277,6 +281,169 @@ func TestRunRejectsNewerEncryptedDesktopCache(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cache-v6.json") || !strings.Contains(err.Error(), "encrypted-only") {
 		t.Fatalf("expected encrypted-cache diagnostic error, got %v", err)
+	}
+}
+
+func TestRunBlocksPostMigrationLocalSourcesBeforeDecrypt(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{encryptedjson.CacheFile, encryptedjson.SupabaseFile} {
+		if err := os.WriteFile(filepath.Join(profile, name), []byte("encrypted"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:        profile,
+			AllowPrivateAPI:    true,
+			AllowDesktopCache:  true,
+			AllowEncryptedJSON: true,
+		},
+		Security: config.SecurityConfig{KeychainPromptMode: "explicit"},
+	}
+	decryptCalls := 0
+	for _, source := range []model.Source{model.SourcePrivateAPI, model.SourceDesktopCache} {
+		result, err := Run(ctx, cfg, st, Options{
+			Source:        source,
+			UnlockSurface: "encrypted-json",
+			DecryptEncryptedJSON: func(context.Context, string, ...string) (map[string]json.RawMessage, error) {
+				decryptCalls++
+				return nil, errors.New("decryptor must not run")
+			},
+		})
+		if err == nil {
+			t.Fatalf("%s sync succeeded with migrated state: %#v", source, result)
+		}
+		if result.Source != source || result.Message != granola.PostMigrationStateMessage {
+			t.Fatalf("%s result = %#v", source, result)
+		}
+		if !strings.Contains(err.Error(), string(source)+" source is blocked") || !strings.Contains(err.Error(), granola.PostMigrationStateMessage) {
+			t.Fatalf("%s error = %v", source, err)
+		}
+	}
+	if decryptCalls != 0 {
+		t.Fatalf("decryptor called %d times", decryptCalls)
+	}
+}
+
+func TestRunAllowsPlaintextSourceWhenOnlyOtherStateIsEncrypted(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Migrated profile (no storage.dek) whose encrypted file belongs to the
+	// OTHER source: desktop-cache must still read its usable plaintext cache.
+	if err := os.WriteFile(filepath.Join(profile, encryptedjson.SupabaseFile), []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{"cache":{"version":6,"state":{"documents":{"doc1":{"id":"doc1","created_at":"2026-05-06T01:00:00Z","updated_at":"2026-05-06T02:00:00Z","title":"Test","type":"meeting","notes_plain":"plain"}}}}}`
+	if err := os.WriteFile(filepath.Join(profile, "cache-v6.json"), []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:       profile,
+			AllowPrivateAPI:   true,
+			AllowDesktopCache: true,
+		},
+		Security: config.SecurityConfig{KeychainPromptMode: "explicit"},
+	}
+	result, err := Run(ctx, cfg, st, Options{Source: model.SourceDesktopCache})
+	if err != nil {
+		t.Fatalf("desktop-cache with usable plaintext cache must not be blocked: %v", err)
+	}
+	if result.Message == granola.PostMigrationStateMessage {
+		t.Fatalf("plaintext desktop-cache reported as migration-blocked: %#v", result)
+	}
+}
+
+func TestRunMigratedImplicitSyncWithoutAnyCacheReportsMigrationBlock(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Migrated profile with encrypted supabase and NO cache file at all: the
+	// fallback must not be selected just because no encrypted cache exists.
+	if err := os.WriteFile(filepath.Join(profile, encryptedjson.SupabaseFile), []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:       profile,
+			PreferredSource:   string(model.SourcePrivateAPI),
+			AllowPrivateAPI:   true,
+			AllowDesktopCache: true,
+		},
+		Security: config.SecurityConfig{KeychainPromptMode: "explicit"},
+	}
+	result, err := Run(ctx, cfg, st, Options{})
+	if err == nil {
+		t.Fatalf("migrated profile without cache should fail: %#v", result)
+	}
+	if result.Message != granola.PostMigrationStateMessage || !strings.Contains(err.Error(), "source is blocked") {
+		t.Fatalf("expected migration diagnostic, got result=%#v err=%v", result, err)
+	}
+}
+
+func TestRunImplicitPrivateAPIFallsBackToPlaintextCacheWhenMigrated(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Migrated profile: supabase is encrypted (private-api unusable) but the
+	// desktop cache is still plaintext, so an implicit sync must fall back.
+	if err := os.WriteFile(filepath.Join(profile, encryptedjson.SupabaseFile), []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{"cache":{"version":6,"state":{"documents":{"doc1":{"id":"doc1","created_at":"2026-05-06T01:00:00Z","updated_at":"2026-05-06T02:00:00Z","title":"Test","type":"meeting","notes_plain":"plain"}}}}}`
+	if err := os.WriteFile(filepath.Join(profile, "cache-v6.json"), []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:       profile,
+			PreferredSource:   string(model.SourcePrivateAPI),
+			AllowPrivateAPI:   true,
+			AllowDesktopCache: true,
+		},
+		Security: config.SecurityConfig{KeychainPromptMode: "explicit"},
+	}
+	result, err := Run(ctx, cfg, st, Options{})
+	if err != nil {
+		t.Fatalf("implicit sync should fall back to the plaintext desktop cache: %v", err)
+	}
+	if result.Source != model.SourceDesktopCache {
+		t.Fatalf("implicit sync source = %q, want desktop-cache", result.Source)
 	}
 }
 
@@ -334,6 +501,9 @@ func TestRunImportsEncryptedDesktopCacheOnlyWithExplicitUnlock(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(cacheEncPath, []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "storage.dek"), []byte("wrapped"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	makeNewer(t, cachePath, cacheEncPath)
@@ -423,6 +593,9 @@ func TestRunEncryptedSupabaseChecksDecryptedToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(cacheEncryptedPath, []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(profile, "storage.dek"), []byte("wrapped"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	makeNewer(t, cachePath, cacheEncryptedPath)


### PR DESCRIPTION
## Root cause

Granola's main process now decrypts `storage.dek` with Electron `safeStorage`, calls `importDek()` in the bundled native `keychain.node`, logs `dek-migrated`, and deletes `storage.dek`. Strings in `keychain.node` identify access group `QZ7DHHLN25.granola` and service `com.granola.app.dek`. `QZ7DHHLN25` is Granola's Team ID, so only Granola-signed code can read that Keychain item.

This was verified on macOS with Granola 7.441.6. A direct `security find-generic-password -s com.granola.app.dek` lookup returns not-found, as expected for an item in Granola's app-scoped access group.

The migration exposed a second bug in graincrawl: both affected sources could exit 0 while importing nothing, and their diagnostics recommended dead-end remedies. Unlocking encrypted JSON cannot recover a DEK that Granola has moved into its private access group, and current Granola versions no longer leave the old plaintext source behind.

## What changed

- Detect the migrated state from local state: `storage.dek` is absent while at least one encrypted source exists.
- Block each source independently, while preserving implicit fallback to a genuinely readable plaintext desktop cache when one exists.
- Return nonzero exits for blocked sync and unlock operations.
- Keep `sources` reporting consistent with actual sync behavior.
- Document the Granola 7.427+ boundary and the resulting diagnostics.

No bypass of Granola's access group is attempted. This is an upstream signing boundary: without Granola-signed code, graincrawl cannot read the migrated DEK and must fail closed.

Fixes #43

Thanks to @nwoonet for the report.
