### PR TITLE
chore(release): prepare v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.3.4 - 2026-07-26
 
 - Detect Granola 7.427+'s app-scoped Keychain migration, fail local sync and unlock with honest diagnostics, and return a nonzero status instead of silently importing nothing. Thanks @nwoonet.
 


### PR DESCRIPTION
Release prep for v0.3.4: stamp the changelog section that ships the Granola 7.427+ Keychain-migration fix (#50).
