### PR TITLE
chore(release): prepare v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## v0.3.5 - Unreleased
+## v0.3.5 - 2026-07-26
+
+- Re-release v0.3.4's content through the official signed and notarized release pipeline; v0.3.4's macOS archives were signed but not notarized.
 
 ## v0.3.4 - 2026-07-26
 


### PR DESCRIPTION
Prepare the superseding v0.3.5 release through the official unified notarized pipeline.