### PR TITLE
build: unify Makefile targets across crawler repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Standardize maintainer Make targets, keep local release commands fail-closed on unified CI, and require notarization when verifying legacy macOS archives.
+
 ## v0.3.5 - 2026-07-26
 
 - Re-release v0.3.4's content through the official signed and notarized release pipeline; v0.3.4's macOS archives were signed but not notarized.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,5 @@ boundary.
 Run before handoff:
 
 ```bash
-go mod tidy
-git diff --exit-code -- go.mod go.sum
-go vet ./...
-go test ./...
+make check
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-.PHONY: test vet tidy check build run smoke release-snapshot release-artifacts clean
+.DEFAULT_GOAL := help
 
 VERSION ?= 0.0.0-dev
+TAG ?=
+ARCHIVES ?=
+GORELEASER := GOWORK=off go run github.com/goreleaser/goreleaser/v2@v2.17.1
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w \
@@ -8,25 +11,52 @@ LDFLAGS := -s -w \
 	-X github.com/openclaw/graincrawl/internal/buildinfo.Commit=$(COMMIT) \
 	-X github.com/openclaw/graincrawl/internal/buildinfo.Date=$(DATE)
 
-test:
-	GOWORK=off go test -count=1 ./...
+.PHONY: help build test run fmt vet tidy deps lint check smoke snapshot release-snapshot release release-artifacts verify-release clean
 
-vet:
-	GOWORK=off go vet ./...
+help: ## Print available targets.
+	@awk 'BEGIN {FS = ":.*## "; printf "Usage: make <target>\n\nTargets:\n"} /^[a-zA-Z0-9_.-]+:.*## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-tidy:
-	GOWORK=off go mod tidy
-
-check: tidy vet test
-	git diff --exit-code -- go.mod go.sum
-
-build:
+build: ## Build the CLI into bin/graincrawl.
 	GOWORK=off go build -trimpath -ldflags "$(LDFLAGS)" -o bin/graincrawl ./cmd/graincrawl
 
-run:
+test: ## Run the full test suite.
+	GOWORK=off go test -count=1 ./...
+
+run: ## Run the CLI help surface.
 	GOWORK=off go run ./cmd/graincrawl --help
 
-smoke: build
+fmt: ## Check Go source formatting.
+	@set -e; changed="$$(gofmt -l .)"; \
+	if [ -n "$$changed" ]; then printf 'gofmt wants changes in:\n%s\n' "$$changed"; exit 1; fi
+
+vet: ## Run go vet.
+	GOWORK=off go vet ./...
+
+tidy: ## Tidy module metadata.
+	GOWORK=off go mod tidy
+
+deps: ## Verify module metadata and known vulnerabilities.
+	GOWORK=off go mod verify
+	$(MAKE) tidy
+	git diff --exit-code -- go.mod go.sum
+	GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./...
+
+lint: vet ## Run static analysis enforced by CI.
+	@output_file="$$(mktemp)"; trap 'rm -f "$$output_file"' EXIT; \
+	if ! GOWORK=off go run golang.org/x/tools/cmd/deadcode@v0.46.0 -test ./... > "$$output_file"; then \
+		cat "$$output_file"; exit 1; \
+	fi; \
+	if [ -s "$$output_file" ]; then cat "$$output_file"; exit 1; fi
+
+check: ## Run every local gate enforced by CI.
+	$(MAKE) deps
+	$(MAKE) fmt
+	$(MAKE) lint
+	$(MAKE) test
+	$(MAKE) smoke
+	$(MAKE) snapshot
+
+smoke: build ## Smoke-test the CLI control surface in isolated directories.
 	set -eu; \
 	tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$tmp"' EXIT; \
@@ -39,11 +69,21 @@ smoke: build
 	env HOME="$$tmp/home" XDG_CONFIG_HOME="$$tmp/xdg-config" XDG_CACHE_HOME="$$tmp/xdg-cache" XDG_STATE_HOME="$$tmp/xdg-state" ./bin/graincrawl --config "$$cfg" tui --json; \
 	env HOME="$$tmp/home" XDG_CONFIG_HOME="$$tmp/xdg-config" XDG_CACHE_HOME="$$tmp/xdg-cache" XDG_STATE_HOME="$$tmp/xdg-state" ./bin/graincrawl --config "$$cfg" snapshot create --out "$$tmp/snapshot" --json
 
-release-snapshot:
-	GOWORK=off goreleaser release --snapshot --clean --skip=publish
+snapshot: ## Build credential-free snapshot artifacts without publishing.
+	$(GORELEASER) release --snapshot --clean --skip=publish
 
-release-artifacts:
-	@./scripts/package-graincrawl-release.sh "$(VERSION)"
+release-snapshot: snapshot ## Alias for snapshot.
 
-clean:
+release: ## Refuse local publication and print the official CI command.
+	@echo "release is CI-only; run:" >&2
+	@echo "gh workflow run release-unified.yml --repo openclaw/graincrawl -f version=X.Y.Z" >&2
+	@false
+
+release-artifacts: release ## Alias for release.
+
+verify-release: ## Verify legacy macOS archives for TAG=vX.Y.Z ARCHIVES='path ...'.
+	@test -n "$(TAG)" && test -n "$(ARCHIVES)" || (echo "usage: make verify-release TAG=v0.3.5 ARCHIVES='dist/graincrawl_0.3.5_darwin_*.tar.gz'" >&2; exit 2)
+	./scripts/verify-graincrawl-release.sh "$(TAG)" $(ARCHIVES)
+
+clean: ## Remove local build and snapshot artifacts.
 	rm -rf bin dist

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -6,11 +6,7 @@ Cloudsmith APT/RPM repositories.
 ## Local Checks
 
 ```bash
-GOWORK=off go mod tidy
-git diff --exit-code -- go.mod go.sum
-GOWORK=off go vet ./...
-GOWORK=off go test -count=1 ./...
-make smoke
+make check
 graincrawl check-update --json
 ```
 
@@ -18,14 +14,15 @@ The smoke target uses temp `HOME`, temp XDG dirs, temp config, temp cache, and a
 temp SQLite database. Do not run distribution checks against a live personal
 archive.
 
-If GoReleaser is installed:
+For credential-free development artifacts:
 
 ```bash
-make release-snapshot
+make snapshot
 ```
 
 That creates local snapshot archives, checksums, `.deb`, and `.rpm` packages
-under `dist/` without publishing or requiring signing credentials.
+under `dist/` without publishing or requiring signing credentials. The target
+uses a pinned GoReleaser module version, so Go can fetch the tool when needed.
 
 ## Unified Release
 
@@ -34,7 +31,9 @@ fleet release pipeline pinned to its compatible `@v1` contract. Dispatch it
 from the protected `main` head with the changelog version already prepared:
 
 ```bash
-gh workflow run release-unified.yml -f version=0.3.3
+make release
+# release refuses locally and prints:
+gh workflow run release-unified.yml --repo openclaw/graincrawl -f version=X.Y.Z
 ```
 
 The pipeline freezes an annotated `v0.3.3` tag, runs the GoReleaser matrix,
@@ -67,12 +66,14 @@ gh workflow run publish-rpm.yml -f tag_name=v0.3.3
 `release-legacy.yml`, `release-assets.yml`, and `homebrew-tap.yml` are
 manual-only fallbacks. They exist to validate or recover releases made by the
 old local signing path and never trigger from tags or release publication.
-`make release-artifacts` and `scripts/package-graincrawl-release.sh` fail closed
-and point maintainers to `release-unified.yml`; the former local path could sign
-macOS binaries without notarizing them. Use `make release-snapshot` for local,
-credential-free packaging. `scripts/verify-graincrawl-release.sh` remains
+`make release-artifacts` remains an alias for the fail-closed `release` target,
+and `scripts/package-graincrawl-release.sh` also points maintainers to
+`release-unified.yml`; the former local path could sign macOS binaries without
+notarizing them. `make release-snapshot` remains an alias for the credential-free
+`snapshot` target. `make verify-release TAG=vX.Y.Z ARCHIVES='path ...'` remains
 available for inspecting legacy archives and their per-archive `.sha256`
-sidecars, but it is not a publishing path.
+sidecars, including Apple notarization assessment, but it is not a publishing
+path.
 
 ## Secrets
 

--- a/scripts/verify-graincrawl-release.sh
+++ b/scripts/verify-graincrawl-release.sh
@@ -57,6 +57,7 @@ for archive in "$@"; do
   [[ -x "$binary" ]]
 
   codesign --verify --strict -R="$REQUIREMENT" --verbose=2 "$binary"
+  codesign --verify --strict --check-notarization -R=notarized "$binary"
   signature=$(codesign -dvvv "$binary" 2>&1)
   grep -Fx "Identifier=$IDENTIFIER" <<<"$signature" >/dev/null
   grep -Fx "TeamIdentifier=$EXPECTED_TEAM_ID" <<<"$signature" >/dev/null


### PR DESCRIPTION
## Summary

- standardize the shared crawler Make targets and make help the default
- keep legacy snapshot and release-artifact names as compatibility aliases
- route official releases exclusively through unified CI and strengthen legacy archive verification with Apple notarization assessment

## Proof

- make help
- make check
- make release refusal prints the exact unified workflow dispatch command
- autoreview clean with no accepted or actionable findings
