### PR TITLE
chore(release): prepare v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.3.6 - 2026-08-01
 
 - Standardize maintainer Make targets, keep local release commands fail-closed on unified CI, and require notarization when verifying legacy macOS archives.
 - Refresh terminal width, syscall, text, and SQLite runtime dependencies.


### PR DESCRIPTION
Prepare v0.3.6 for the repository's official unified signed and notarized release pipeline.

Local proof: `make check` (module verification, vulnerability scan, vet, tests, CLI smoke run, and GoReleaser snapshot).
