### PR TITLE
build(deps): bump actions/stale to v11

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mark stale unassigned issues and pull requests
-        uses: actions/stale@v10
+        uses: actions/stale@v11
         with:
           days-before-issue-stale: 14
           days-before-issue-close: 7
@@ -44,7 +44,7 @@ jobs:
             If this PR should be revived, reopen it with current context and validation.
 
       - name: Mark stale assigned issues
-        uses: actions/stale@v10
+        uses: actions/stale@v11
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 10
@@ -65,7 +65,7 @@ jobs:
           close-issue-reason: not_planned
 
       - name: Mark stale assigned pull requests
-        uses: actions/stale@v10
+        uses: actions/stale@v11
         with:
           days-before-issue-stale: -1
           days-before-issue-close: -1


### PR DESCRIPTION
## Summary

- bump all `actions/stale` uses from v10 to v11
- preserve the exact diff and Dependabot authorship from #58
- rerun required checks on the current `main` base

## Why a replacement PR

The Dependabot branch in #58 is marked uneditable and branch protection requires
fresh checks after rebasing onto current `main`. This branch preserves the bot's
commit authorship while making those required checks possible.

## Validation

- original #58 checks were green for CI, CodeQL, secret scanning, and Socket
- replacement branch is based on current `origin/main`
