### PR TITLE
fix(sync): fall back when private API credentials are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fall back to a readable desktop cache when implicit private API sync has no local credentials, while keeping explicit private API failures path-free.
+
 ## v0.3.6 - 2026-08-01
 
 - Standardize maintainer Make targets, keep local release commands fail-closed on unified CI, and require notarization when verifying legacy macOS archives.

--- a/internal/syncer/private_api.go
+++ b/internal/syncer/private_api.go
@@ -3,6 +3,7 @@ package syncer
 import (
 	"context"
 	"errors"
+	"os"
 	"time"
 
 	"github.com/openclaw/graincrawl/internal/config"
@@ -21,6 +22,9 @@ func PrivateAPI(ctx context.Context, cfg config.Config, st *store.Store, opts Op
 	paths := granola.Paths(cfg.Granola.ProfilePath, cfg.Granola.AppPath)
 	_, tokens, user, err := granola.ReadSupabase(paths.Supabase)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Result{}, ErrPrivateAPITokenNotFound
+		}
 		return Result{}, err
 	}
 	return privateAPIWithSession(ctx, cfg, st, opts, tokens, user, "")

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -488,6 +488,45 @@ func TestRunFallsBackToDesktopCacheForImplicitExpiredPrivateAPI(t *testing.T) {
 	}
 }
 
+func TestRunFallsBackToDesktopCacheWhenPrivateAPICredentialsAreMissing(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	profile := filepath.Join(root, "Granola")
+	if err := os.MkdirAll(profile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cacheRaw := `{"cache":{"version":8,"state":{"documents":{"doc1":{"id":"doc1","created_at":"2026-08-01T01:00:00Z","updated_at":"2026-08-01T02:00:00Z","title":"Synthetic","type":"meeting","notes_plain":"synthetic"}},"transcripts":{}}}}`
+	if err := os.WriteFile(filepath.Join(profile, "cache-v6.json"), []byte(cacheRaw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(ctx, filepath.Join(root, "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:       profile,
+			PreferredSource:   "private-api",
+			AllowPrivateAPI:   true,
+			AllowDesktopCache: true,
+		},
+		Sync: config.SyncConfig{DefaultLimit: 100},
+	}
+	result, err := Run(ctx, cfg, st, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Source != model.SourceDesktopCache || result.Notes != 1 {
+		t.Fatalf("expected implicit sync to import the desktop cache, got %#v", result)
+	}
+	if _, err := Run(ctx, cfg, st, Options{Source: model.SourcePrivateAPI}); !errors.Is(err, ErrPrivateAPITokenNotFound) {
+		t.Fatalf("explicit private-api should report missing authentication, got %v", err)
+	} else if strings.Contains(err.Error(), profile) {
+		t.Fatalf("explicit private-api diagnostic exposed the profile path: %v", err)
+	}
+}
+
 func TestRunImportsEncryptedDesktopCacheOnlyWithExplicitUnlock(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running implicit sync would get a missing-file error instead of importing a readable desktop cache when local private API credentials were absent.

## Why This Change Was Made

Missing `supabase.json` is now classified as unavailable authentication at the private API adapter boundary. That lets implicit sync use the existing desktop-cache fallback while explicit private API requests still fail closed with a path-free diagnostic.

## User Impact

Default sync continues from a readable Granola desktop cache when private API credentials are not present. Explicit `--source private-api` remains strict and reports `Granola access token not found` without exposing the local profile path.

## Evidence

- `GOWORK=off go mod tidy`
- `git diff --exit-code -- go.mod go.sum`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test ./...`
- Focused regression: implicit missing-auth sync imported one synthetic desktop-cache note; explicit private API sync exited 1 with a path-free missing-token diagnostic.
- Targeted CLI smoke used an isolated temporary HOME/XDG/profile/database and synthetic cache data only.
