### PR TITLE
fix(cli): honor trailing json flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fall back to a readable desktop cache when implicit private API sync has no local credentials, while keeping explicit private API failures path-free.
+- Honor trailing `--json` after subcommands, matching the documented examples and crawlkit control manifest.
 
 ## v0.3.6 - 2026-08-01
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -498,6 +499,30 @@ func TestAppPreservesFlagLikeCommandArguments(t *testing.T) {
 	}
 	if !strings.Contains(searchOut.String(), "--config") {
 		t.Fatalf("search output lost flag-like query: %s", searchOut.String())
+	}
+}
+
+func TestAppAcceptsGlobalFlagsAfterCommand(t *testing.T) {
+	cfgPath := writeTestConfig(t)
+	var out bytes.Buffer
+	app := App{Stdout: &out}
+
+	if err := app.Run(context.Background(), []string{"--config", cfgPath, "status", "--json"}); err != nil {
+		t.Fatalf("status with trailing --json failed: %v", err)
+	}
+	if !strings.Contains(out.String(), `"schema_version"`) || !strings.Contains(out.String(), `"counts"`) {
+		t.Fatalf("status with trailing --json did not emit JSON: %s", out.String())
+	}
+}
+
+func TestParseGlobalFlagsDoesNotConsumeCommandConfigArgument(t *testing.T) {
+	flags, rest := parseGlobalFlags([]string{"search", "--config", "foo"})
+	if flags.ConfigPath != "" {
+		t.Fatalf("command argument became global config path: %q", flags.ConfigPath)
+	}
+	want := []string{"search", "--config", "foo"}
+	if !slices.Equal(rest, want) {
+		t.Fatalf("command arguments changed: got %q want %q", rest, want)
 	}
 }
 

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -28,6 +28,10 @@ func parseGlobalFlags(args []string) (GlobalFlags, []string) {
 			}
 		default:
 			rest = append(rest, args[i:]...)
+			if len(rest) > 1 && rest[len(rest)-1] == "--json" {
+				flags.JSON = true
+				rest = rest[:len(rest)-1]
+			}
 			return flags, rest
 		}
 	}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users following the documented `graincrawl <command> --json` form would receive text output instead of JSON. The same mismatch affected JSON commands advertised through the crawlkit control manifest.

## Why This Change Was Made

The CLI now recognizes a final `--json` after the subcommand while leaving other command arguments under the command's ownership. Regression coverage verifies both the trailing JSON form and preservation of flag-like search arguments.

## User Impact

Documented commands such as `graincrawl status --json`, plus control-manifest commands for doctor, notes, sync, and unlock, now emit the promised JSON without requiring callers to move the flag before the subcommand.

## Evidence

- `make check`
- Focused CLI regression tests
- Redacted aggregate-only validation against a copied local Granola archive: status, notes, search, note detail, transcripts, panels, TUI JSON, Markdown export, and snapshot round-trip passed without printing private content
- Live post-migration source checks remained fail-closed without Keychain prompts or path leakage
- AWS Crabbox Linux command execution was blocked before lease allocation: the standard class remained queued, then the smaller-class retry hit a coordinator Durable Object reset during deployment. No remote test command ran.
