### PR TITLE
fix(cli): preserve json query arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Fall back to a readable desktop cache when implicit private API sync has no local credentials, while keeping explicit private API failures path-free.
-- Honor trailing `--json` after subcommands, matching the documented examples and crawlkit control manifest.
+- Honor trailing `--json` for structured subcommands while preserving literal `--json` arguments in free-form search and SQL queries.
 
 ## v0.3.6 - 2026-08-01
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -515,6 +515,59 @@ func TestAppAcceptsGlobalFlagsAfterCommand(t *testing.T) {
 	}
 }
 
+func TestAppPreservesTrailingJSONSearchArgument(t *testing.T) {
+	cfgPath := writeTestConfig(t)
+	var out bytes.Buffer
+	app := App{Stdout: &out}
+
+	if err := app.Run(context.Background(), []string{"--config", cfgPath, "search", "--json"}); err != nil {
+		t.Fatalf("search with literal trailing --json failed: %v", err)
+	}
+}
+
+func TestParseGlobalFlagsPreservesFreeFormJSONArguments(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantJSON bool
+		wantRest []string
+	}{
+		{
+			name:     "search literal",
+			args:     []string{"search", "--json"},
+			wantRest: []string{"search", "--json"},
+		},
+		{
+			name:     "search json output prefix",
+			args:     []string{"--json", "search", "--json"},
+			wantJSON: true,
+			wantRest: []string{"search", "--json"},
+		},
+		{
+			name:     "sql trailing argument",
+			args:     []string{"sql", "select 1", "--json"},
+			wantRest: []string{"sql", "select 1", "--json"},
+		},
+		{
+			name:     "sql json output prefix",
+			args:     []string{"--json", "sql", "select 1", "--json"},
+			wantJSON: true,
+			wantRest: []string{"sql", "select 1", "--json"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags, rest := parseGlobalFlags(tt.args)
+			if flags.JSON != tt.wantJSON {
+				t.Fatalf("JSON flag = %v, want %v", flags.JSON, tt.wantJSON)
+			}
+			if !slices.Equal(rest, tt.wantRest) {
+				t.Fatalf("command arguments changed: got %q want %q", rest, tt.wantRest)
+			}
+		})
+	}
+}
+
 func TestParseGlobalFlagsDoesNotConsumeCommandConfigArgument(t *testing.T) {
 	flags, rest := parseGlobalFlags([]string{"search", "--config", "foo"})
 	if flags.ConfigPath != "" {

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -28,7 +28,7 @@ func parseGlobalFlags(args []string) (GlobalFlags, []string) {
 			}
 		default:
 			rest = append(rest, args[i:]...)
-			if len(rest) > 1 && rest[len(rest)-1] == "--json" {
+			if acceptsTrailingJSON(rest[0]) && len(rest) > 1 && rest[len(rest)-1] == "--json" {
 				flags.JSON = true
 				rest = rest[:len(rest)-1]
 			}
@@ -36,6 +36,10 @@ func parseGlobalFlags(args []string) (GlobalFlags, []string) {
 		}
 	}
 	return flags, rest
+}
+
+func acceptsTrailingJSON(command string) bool {
+	return command != "search" && command != "sql"
 }
 
 func hasFlag(args []string, name string) bool {


### PR DESCRIPTION
Related: #66

## What Problem This Solves

Fixes a compatibility regression where free-form `search` and `sql` commands could lose a legitimate final `--json` argument after trailing JSON support was added for structured subcommands.

## Why This Change Was Made

Trailing `--json` remains available for documented and control-manifest structured commands. Free-form search and SQL commands now retain every post-command argument; callers can continue to request JSON output with the global prefix form.

## User Impact

`graincrawl search --json` once again searches for the literal term, and SQL arguments ending in `--json` are preserved. Commands such as `graincrawl status --json` continue to emit JSON.

## Evidence

- `GOWORK=off go test -count=1 ./internal/cli`
- `make check`
- Regression coverage for literal trailing `--json` in search and SQL, prefixed JSON output, documented trailing JSON, and command-owned `--config`
