### PR TITLE
fix(ci): restore Crabbox AWS provisioning

### DIFF
--- a/.crabbox.yaml
+++ b/.crabbox.yaml
@@ -24,7 +24,7 @@ actions:
   ephemeral: true
 aws:
   region: eu-west-1
-  rootGB: 160
+  rootGB: 400
 sync:
   delete: true
   checksum: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fall back to a readable desktop cache when implicit private API sync has no local credentials, while keeping explicit private API failures path-free.
 - Honor trailing `--json` for structured subcommands while preserving literal `--json` arguments in free-form search and SQL queries.
+- Restore Crabbox validation with a root volume that fits the current AWS
+  developer image.
 
 ## v0.3.6 - 2026-08-01
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Graincrawl's configured AWS Crabbox validation could not
provision a runner because its 160 GB root volume was smaller than the current
400 GB developer-image snapshot.

## Why This Change Was Made

Raise the repo's AWS root volume to 400 GB, matching the current Crabbox image
requirement. Keep the change scoped to provisioning; the existing provider,
capacity, hydration, and sync policy remain unchanged.

## User Impact

Maintainers can provision the repository's configured AWS Crabbox runner and
complete GitHub-runner hydration plus the full Go validation and release
snapshot flow.

## Evidence

- Before: brokered AWS provisioning failed for both spot and on-demand
  `c7a.8xlarge` with `InvalidBlockDeviceMapping`: the configured 160 GB volume
  was smaller than snapshot `snap-03a91a1517b4bc210`, which requires at least
  400 GB.
- Config proof: `crabbox config show` resolves
  `provider=aws`, `profile=graincrawl-check`, and `root_gb=400`.
- Plan proof: `crabbox prewarm --dry-run --provider aws --github-runner
  --probe-command true` resolves AWS warmup, GitHub-runner hydration, and a
  no-resync probe.
- Remote proof: provider `aws`, lease `cbx_47f7b0fb9c6b`, Actions hydration run
  `30755759856`, probe run `run_d4c12f26c446`.
- Remote result: module verification, tidy check, `govulncheck`, formatting,
  vet, deadcode, full tests, isolated CLI smoke, and GoReleaser snapshot all
  passed with exit code 0.
- Cleanup: `crabbox stop` reported
  `released lease=cbx_47f7b0fb9c6b server=i-04bb7123ceb02e51c`.
- `git diff --check`
