### PR TITLE
fix(store): avoid concurrent open lock failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   developer image.
 - Update CrawlKit to v0.14.5 and pick up the corrected `go-colorful` v1.4.1
   terminal color conversion.
+- Avoid `SQLITE_BUSY` failures when concurrent commands open an archive whose
+  schema is already current.
 
 ## v0.3.6 - 2026-08-01
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -31,13 +31,15 @@ func Open(ctx context.Context, path string) (*Store, error) {
 		_ = inner.Close()
 		return nil, fmt.Errorf("database schema version %d is newer than supported version %d", current, SchemaVersion)
 	}
-	if err := ensureDeletionColumns(ctx, inner.DB()); err != nil {
-		_ = inner.Close()
-		return nil, err
-	}
-	if err := inner.EnsureSchemaVersion(ctx, SchemaVersion); err != nil {
-		_ = inner.Close()
-		return nil, err
+	if current < SchemaVersion {
+		if err := ensureDeletionColumns(ctx, inner.DB()); err != nil {
+			_ = inner.Close()
+			return nil, err
+		}
+		if err := inner.EnsureSchemaVersion(ctx, SchemaVersion); err != nil {
+			_ = inner.Close()
+			return nil, err
+		}
 	}
 	return &Store{inner: inner}, nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -167,6 +167,38 @@ VALUES('private-api', 'document', 'deleted-doc', 'deleted-doc', '{}', 'hash', '2
 	}
 }
 
+func TestOpenCurrentSchemaConcurrently(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "graincrawl.db")
+	st, err := Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	const workers = 16
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	for range workers {
+		go func() {
+			<-start
+			st, err := Open(ctx, dbPath)
+			if err == nil {
+				err = st.Close()
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	for range workers {
+		if err := <-errs; err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func TestChildUpsertsInheritExistingDocumentTombstone(t *testing.T) {
 	ctx := context.Background()
 	st, err := Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))


### PR DESCRIPTION
## What Problem This Solves

Fixes deterministic `SQLITE_BUSY` failures when two Graincrawl commands open
the same current-schema archive concurrently.

## Why This Change Was Made

Deletion-column migration and tombstone reconciliation were running on every
store open, even after the archive had reached schema v2. Concurrent deferred
transactions could both inspect the schema and then deadlock while upgrading to
a writer.

Run the migration only while upgrading an older schema. Snapshot imports retain
their explicit tombstone reconciliation.

## User Impact

Parallel read commands such as `status` and `sources` no longer fail because
another Graincrawl process opened the archive at the same time.

## Evidence

- Before: 20 copied-live concurrent pairs, 40 commands, 20 failures, all
  `SQLITE_BUSY`.
- After: 20 copied-live concurrent pairs, 40 commands, 0 failures.
- New concurrent-open regression test passed 20 repeated runs.
- Existing schema-v1 deletion migration test passed 20 repeated runs.
- `make check`
- Module verification, govulncheck, formatting, vet, deadcode, full tests,
  isolated CLI smoke, and GoReleaser snapshot all passed.
- `git diff --check`
