### PR TITLE
fix(cli): honor trailing json after search queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - Fall back to a readable desktop cache when implicit private API sync has no local credentials, while keeping explicit private API failures path-free.
-- Honor trailing `--json` for structured subcommands while preserving literal `--json` arguments in free-form search and SQL queries.
+- Honor trailing `--json` for structured subcommands and searches with an
+  explicit query, while preserving literal `--json` arguments and free-form SQL.
 - Restore Crabbox validation with a root volume that fits the current AWS
   developer image.
 - Update CrawlKit to v0.14.5 and pick up the corrected `go-colorful` v1.4.1

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -525,6 +525,19 @@ func TestAppPreservesTrailingJSONSearchArgument(t *testing.T) {
 	}
 }
 
+func TestAppAcceptsTrailingJSONAfterSearchQuery(t *testing.T) {
+	cfgPath := writeTestConfig(t)
+	var out bytes.Buffer
+	app := App{Stdout: &out}
+
+	if err := app.Run(context.Background(), []string{"--config", cfgPath, "search", "needle", "--json"}); err != nil {
+		t.Fatalf("search with trailing --json failed: %v", err)
+	}
+	if !strings.Contains(out.String(), `"ok": true`) || !strings.Contains(out.String(), `"notes"`) {
+		t.Fatalf("search with trailing --json did not emit JSON: %s", out.String())
+	}
+}
+
 func TestParseGlobalFlagsPreservesFreeFormJSONArguments(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -542,6 +555,12 @@ func TestParseGlobalFlagsPreservesFreeFormJSONArguments(t *testing.T) {
 			args:     []string{"--json", "search", "--json"},
 			wantJSON: true,
 			wantRest: []string{"search", "--json"},
+		},
+		{
+			name:     "search trailing json output",
+			args:     []string{"search", "needle", "--json"},
+			wantJSON: true,
+			wantRest: []string{"search", "needle"},
 		},
 		{
 			name:     "sql trailing argument",

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -28,7 +28,7 @@ func parseGlobalFlags(args []string) (GlobalFlags, []string) {
 			}
 		default:
 			rest = append(rest, args[i:]...)
-			if acceptsTrailingJSON(rest[0]) && len(rest) > 1 && rest[len(rest)-1] == "--json" {
+			if acceptsTrailingJSON(rest) {
 				flags.JSON = true
 				rest = rest[:len(rest)-1]
 			}
@@ -38,8 +38,18 @@ func parseGlobalFlags(args []string) (GlobalFlags, []string) {
 	return flags, rest
 }
 
-func acceptsTrailingJSON(command string) bool {
-	return command != "search" && command != "sql"
+func acceptsTrailingJSON(args []string) bool {
+	if len(args) < 2 || args[len(args)-1] != "--json" {
+		return false
+	}
+	switch args[0] {
+	case "search":
+		return len(args) > 2
+	case "sql":
+		return false
+	default:
+		return true
+	}
 }
 
 func hasFlag(args []string, name string) bool {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `graincrawl search <query> --json` received
successful empty stdout instead of a JSON response.

## Why This Change Was Made

Treat trailing `--json` as output mode only when a search has an explicit query.
The literal one-token query `search --json` remains supported, and SQL keeps its
prefix-only JSON form because its free-form argument grammar is ambiguous.

## User Impact

Search now follows the same practical trailing JSON convention as structured
commands without breaking literal flag-like search terms.

## Evidence

- Reproduced against a live local Granola archive: prefix JSON returned four
  matches while trailing JSON returned zero bytes.
- After the fix, the same trailing form returned valid JSON with four matches.
- Added parser and command-level regressions for output mode and literal mode.
- `make check`
