### PR TITLE
chore(release): prepare v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.3.7 - 2026-08-02
 
 - Fall back to a readable desktop cache when implicit private API sync has no local credentials, while keeping explicit private API failures path-free.
 - Honor trailing `--json` for structured subcommands and searches with an


### PR DESCRIPTION
## What Problem This Solves

Prepares the validated Graincrawl changes for the `v0.3.7` unified release.

## Why This Change Was Made

Dates the current changelog section as `v0.3.7 - 2026-08-02`, which is the
release pipeline's source of byte-exact release notes.

## User Impact

Enables the protected unified workflow to publish Graincrawl v0.3.7.

## Evidence

- `make check`
- Exact-main Crabbox AWS validation passed on Go 1.26.5.
- Final live Granola 7.452.1 validation passed across source diagnostics,
  archive reads, search, SQL, TUI JSON, Markdown export, concurrency, and
  snapshot restore.
