### PR TITLE
feat(sync): add official Granola public API source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add an explicit official Granola public API source for scoped read-only note,
+  summary, and transcript archiving without depending on the desktop app's
+  local encryption key.
 - Rewrite the README around installation and first-use workflows, with the full command reference moved into `docs/commands.md`.
 
 ## v0.3.7 - 2026-08-02

--- a/README.md
+++ b/README.md
@@ -37,13 +37,21 @@ graincrawl notes
 graincrawl tui
 ```
 
-`sync` uses the configured source, which defaults to Granola's private desktop API session. When that session is unavailable and a readable plaintext desktop cache exists, an implicit sync falls back to the cache.
+`sync` uses the configured source, which defaults to Granola's private desktop API session. When that session is unavailable and a readable plaintext desktop cache exists, an implicit sync falls back to the cache. Granola's official public API is also supported when explicitly enabled:
+
+```bash
+GRANOLA_PUBLIC_API_KEY="..." \
+  GRAINCRAWL_ALLOW_PUBLIC_API=true \
+  graincrawl sync --source public-api
+```
+
+For managed environments, inject `GRANOLA_PUBLIC_API_KEY` at runtime from the operator's secret manager instead of writing it to the config file.
 
 ## Sources and archive contents
 
-The default private API source archives notes, transcripts, panels, people, workspaces, and retained source payloads. The desktop cache provides an offline fallback when `cache-v6.json` is readable. Both sources are read-only against Granola; graincrawl writes only to its own config, cache, and SQLite archive.
+The default private API source archives notes, transcripts, panels, people, workspaces, and retained source payloads. The desktop cache provides an offline fallback when `cache-v6.json` is readable. The official public API archives available notes, summaries, and transcripts, but does not expose panels or deletion events. All sources are read-only against Granola; graincrawl writes only to its own config, cache, and SQLite archive.
 
-Granola 7.427 and later can store its data-encryption key in an app-scoped Keychain item that graincrawl cannot access. `graincrawl doctor` detects this boundary. Existing archived data stays readable, and a source with usable plaintext state still works. See the [security model](docs/security.md) for the exact source and legacy encrypted-JSON behavior.
+Granola 7.427 and later can store its data-encryption key in an app-scoped Keychain item that graincrawl cannot access. `graincrawl doctor` detects this boundary. Existing archived data stays readable, and the official public API remains independent of the local Keychain boundary. See the [security model](docs/security.md) for the exact source and legacy encrypted-JSON behavior.
 
 ## Find and export notes
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -15,7 +15,7 @@ The product should feel like the other crawl apps:
 - strict handling of live app stores and secrets
 
 The important difference is that Granola has multiple overlapping access
-surfaces: a private API, a public Enterprise API, plaintext desktop cache,
+surfaces: a private API, an official public API, plaintext desktop cache,
 Electron safeStorage encrypted JSON, OPFS SQLCipher state, and a bundled
 companion CLI. `graincrawl` should treat those as source adapters with clear
 trust and support boundaries, not one mushy importer.
@@ -206,21 +206,22 @@ API stability:
 Optional official adapter.
 
 Use this only when the operator supplies an official Granola public API key.
-Current public docs indicate Enterprise access and a public notes endpoint.
+Business and Enterprise workspaces can create scoped personal API keys.
 
-Capabilities are expected to be narrower than private API. The adapter should
-not pretend it can provide transcripts or panels until proven.
+The adapter archives notes, summaries, calendar-event identity, and optional
+transcripts. The official API does not expose panels or deletion events, so
+graincrawl must not infer deletion from a note disappearing from a later page.
 
 Configuration:
 
 - `GRANOLA_PUBLIC_API_KEY`
-- `graincrawl config set public_api_key`
-- optional keychain storage through `graincrawl secrets set public-api-key`
+- `allow_public_api = true` or `GRAINCRAWL_ALLOW_PUBLIC_API=true`
+- never persist the API key in graincrawl config or SQLite
 
 Commands should make source limitations obvious:
 
 - `graincrawl sync --source public-api`
-- `graincrawl doctor public-api`
+- `graincrawl sources`
 
 ### `desktop-cache`
 
@@ -460,6 +461,7 @@ Environment variables:
 - `GRAINCRAWL_SOURCE`
 - `GRANOLA_PUBLIC_API_KEY`
 - `GRAINCRAWL_ALLOW_PRIVATE_API`
+- `GRAINCRAWL_ALLOW_PUBLIC_API`
 - `GRAINCRAWL_HELPER_TIMEOUT`
 - `GRAINCRAWL_NO_KEYCHAIN`
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -11,6 +11,7 @@ profile_path = "~/Library/Application Support/Granola"
 app_path = "/Applications/Granola.app"
 preferred_source = "private-api"
 allow_private_api = true
+# Requires GRANOLA_PUBLIC_API_KEY at process launch.
 allow_public_api = false
 allow_companion_cli = true
 allow_desktop_cache = true

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,13 +24,14 @@ graincrawl [--json] [--config <path>] [--version] <command> [args]
 | `graincrawl sources` | Show which source adapters the current config allows. |
 | `graincrawl sync` | Sync from the configured source; `refresh` is an alias. |
 | `graincrawl sync --source private-api` | Require the private desktop API session. |
+| `graincrawl sync --source public-api` | Use Granola's official API with `GRANOLA_PUBLIC_API_KEY`. |
 | `graincrawl sync --source desktop-cache` | Import the local plaintext desktop cache. |
 | `graincrawl sync --limit <n>` | Limit the number of notes processed. |
 | `graincrawl sync --no-transcripts --no-panels` | Skip transcript and panel hydration for this run. |
 | `graincrawl runs --limit <n>` | List recent sync runs. |
 | `graincrawl status` | Show archive counts and the SQLite path. |
 
-`private-api` and `desktop-cache` are the supported sync sources in this build. The config also names reserved adapters that are not enabled by the current implementation.
+`private-api`, `public-api`, and `desktop-cache` are supported sync sources. `public-api` must be explicitly enabled with `allow_public_api = true` or `GRAINCRAWL_ALLOW_PUBLIC_API=true`; its key is read only from `GRANOLA_PUBLIC_API_KEY`. It archives notes, summaries, and transcripts available to the key, but the official API does not expose panels or deletion events.
 
 ## Read the archive
 
@@ -72,6 +73,8 @@ Merge imports keep existing local payloads on identity conflicts and preserve to
 | `graincrawl version` | Show version, commit, and build date. |
 
 Legacy encrypted JSON requires `allow_encrypted_json = true` and an explicit unlock command or sync flag. Decrypted payloads stay in process memory. The [security model](security.md) documents the Keychain boundary and Granola 7.427+ behavior.
+
+The public API key is never written to graincrawl config or SQLite. Inject it at runtime, for example with `op run --env-file <template> -- graincrawl sync --source public-api`.
 
 ## JSON and automation
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,6 +7,7 @@ already present, plus plaintext cache fallback when Granola still writes one.
 ## Defaults
 
 - `allow_private_api = true`
+- `allow_public_api = false`
 - `allow_desktop_cache = true`
 - `allow_encrypted_json = false`
 - `allow_opfs = false`
@@ -16,6 +17,12 @@ already present, plus plaintext cache fallback when Granola still writes one.
 That means `graincrawl doctor`, `status`, `notes`, and `export` must not prompt
 macOS Keychain. A Keychain prompt is allowed only after the user explicitly
 enables encrypted sources and invokes an explicit unlock command.
+
+The official `public-api` source is independent of Granola's local profile and
+macOS Keychain state. It is disabled by default, requires an explicit
+`allow_public_api = true` or `GRAINCRAWL_ALLOW_PUBLIC_API=true`, and reads its
+credential only from `GRANOLA_PUBLIC_API_KEY`. graincrawl does not save that
+key to config, SQLite, logs, diagnostics, or source objects.
 
 ## Keychain Boundary
 
@@ -46,12 +53,16 @@ plaintext state is neither blocked nor advertised as unavailable.
 
 This is an upstream code-signing and Keychain access-group boundary, not a
 graincrawl bug. The legacy unlock path remains available only for profiles that
-still contain `storage.dek`; existing graincrawl archives remain readable.
+still contain `storage.dek`; existing graincrawl archives remain readable. The
+official public API remains a supportable read-only source across this boundary
+when the Granola account and API key scope expose the requested notes.
 
 ## Operational Rules
 
 - Do not log tokens, refresh tokens, decrypted keys, cookies, or raw encrypted
   payloads.
+- Inject `GRANOLA_PUBLIC_API_KEY` at process launch; do not store it in TOML,
+  shell profiles, command history, or fleet manifests.
 - Do not read or mutate live Granola files in tests.
 - Snapshot encrypted files into memory before Keychain access; never write
   decrypted Granola JSON to disk.

--- a/internal/cli/control.go
+++ b/internal/cli/control.go
@@ -41,13 +41,14 @@ func controlManifest(configPath string, cfg config.Config) control.Manifest {
 		DefaultCache:    cfg.Paths.CacheDir,
 		DefaultLogs:     cfg.Paths.LogDir,
 	}
-	manifest.Capabilities = []string{"metadata", "status", "doctor", "sync", "desktop-cache", "notes", "sql", "export", "snapshot", "tui"}
+	manifest.Capabilities = []string{"metadata", "status", "doctor", "sync", "public-api", "desktop-cache", "notes", "sql", "export", "snapshot", "tui"}
 	manifest.Commands = map[string]control.Command{
 		"metadata":             {Title: "Metadata", Argv: []string{"graincrawl", "metadata", "--json"}, JSON: true},
 		"status":               {Title: "Status", Argv: []string{"graincrawl", "status", "--json"}, JSON: true},
 		"check-update":         {Title: "Check for updates", Argv: []string{"graincrawl", "check-update", "--json"}, JSON: true},
 		"doctor":               {Title: "Doctor", Argv: []string{"graincrawl", "doctor", "--json"}, JSON: true},
 		"sync":                 {Title: "Sync", Argv: []string{"graincrawl", "sync", "--source", cfg.Granola.PreferredSource, "--json"}, JSON: true, Mutates: true},
+		"public-api-sync":      {Title: "Public API sync", Argv: []string{"graincrawl", "sync", "--source", "public-api", "--json"}, JSON: true, Mutates: true},
 		"desktop-cache-import": {Title: "Desktop cache import", Argv: []string{"graincrawl", "sync", "--source", "desktop-cache", "--json"}, JSON: true, Mutates: true},
 		"notes":                {Title: "Notes", Argv: []string{"graincrawl", "notes", "--json"}, JSON: true},
 		"sql":                  {Title: "Read-only SQL", Argv: []string{"graincrawl", "--json", "sql", "select count(*) as notes from notes"}, JSON: true},

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -36,6 +36,7 @@ Commands:
 Examples:
   graincrawl doctor --json
   graincrawl sync --source private-api
+  GRAINCRAWL_ALLOW_PUBLIC_API=true GRANOLA_PUBLIC_API_KEY=... graincrawl sync --source public-api
   graincrawl sync --source private-api --unlock encrypted-json
   graincrawl sync --source desktop-cache
   graincrawl unlock encrypted-json

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ type APIConfig struct {
 	Platform            string `toml:"platform" json:"platform"`
 	IncludeSharedWithMe bool   `toml:"include_shared_with_me" json:"include_shared_with_me"`
 	RefreshMode         string `toml:"refresh_mode" json:"refresh_mode"`
+	PublicBaseURL       string `toml:"-" json:"-"`
 }
 
 type SyncConfig struct {
@@ -86,6 +87,7 @@ func Defaults() (Config, string, error) {
 			AppPath:           "/Applications/Granola.app",
 			PreferredSource:   envOr("GRAINCRAWL_SOURCE", "private-api"),
 			AllowPrivateAPI:   envBool("GRAINCRAWL_ALLOW_PRIVATE_API", true),
+			AllowPublicAPI:    envBool("GRAINCRAWL_ALLOW_PUBLIC_API", false),
 			AllowCompanionCLI: true,
 			AllowDesktopCache: true,
 		},
@@ -128,6 +130,9 @@ func Load(path string) (Config, string, error) {
 		}
 	} else if !os.IsNotExist(err) {
 		return Config{}, resolved, err
+	}
+	if _, ok := os.LookupEnv("GRAINCRAWL_ALLOW_PUBLIC_API"); ok {
+		cfg.Granola.AllowPublicAPI = envBool("GRAINCRAWL_ALLOW_PUBLIC_API", false)
 	}
 	return cfg, resolved, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -21,5 +23,50 @@ func TestDefaultsUseGraincrawlPaths(t *testing.T) {
 	}
 	if !cfg.Sync.IncludeTranscripts || !cfg.Sync.IncludePanels {
 		t.Fatalf("expected transcripts and panels enabled")
+	}
+}
+
+func TestDefaultsAllowPublicAPIOnlyWhenExplicitlyEnabled(t *testing.T) {
+	t.Setenv("GRAINCRAWL_ALLOW_PUBLIC_API", "true")
+	cfg, _, err := Defaults()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Granola.AllowPublicAPI {
+		t.Fatal("expected public API source enabled from environment")
+	}
+}
+
+func TestLoadPublicAPIEnvironmentOverridesConfigDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[granola]\nallow_public_api = false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GRAINCRAWL_ALLOW_PUBLIC_API", "true")
+	cfg, _, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Granola.AllowPublicAPI {
+		t.Fatal("expected explicit environment gate to override config default")
+	}
+}
+
+func TestSaveOmitsTestOnlyPublicBaseURL(t *testing.T) {
+	cfg, _, err := Defaults()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.API.PublicBaseURL = "https://example.invalid"
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) == "" || strings.Contains(string(raw), "public_base_url") || strings.Contains(string(raw), "example.invalid") {
+		t.Fatalf("test-only base URL was persisted:\n%s", raw)
 	}
 }

--- a/internal/publicapi/client.go
+++ b/internal/publicapi/client.go
@@ -1,0 +1,170 @@
+package publicapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	BaseURL          = "https://public-api.granola.ai"
+	KeyEnv           = "GRANOLA_PUBLIC_API_KEY"
+	pageLimit        = 30
+	maxResponseBytes = 64 << 20
+	maxAttempts      = 4
+)
+
+type Client struct {
+	HTTP            *http.Client
+	BaseURL         string
+	APIKey          string
+	RequestInterval time.Duration
+
+	mu          sync.Mutex
+	lastRequest time.Time
+}
+
+func (c *Client) ListNotes(ctx context.Context, cursor string, pageSize int) (NotesResponse, error) {
+	if pageSize <= 0 || pageSize > pageLimit {
+		pageSize = pageLimit
+	}
+	query := url.Values{"page_size": {strconv.Itoa(pageSize)}}
+	if cursor != "" {
+		query.Set("cursor", cursor)
+	}
+	var response NotesResponse
+	err := c.get(ctx, "/v1/notes?"+query.Encode(), &response)
+	return response, err
+}
+
+func (c *Client) GetNote(ctx context.Context, noteID string, includeTranscript bool) (Note, error) {
+	endpoint := "/v1/notes/" + url.PathEscape(noteID)
+	if includeTranscript {
+		endpoint += "?include=transcript"
+	}
+	var note Note
+	err := c.get(ctx, endpoint, &note)
+	return note, err
+}
+
+func (c *Client) get(ctx context.Context, endpoint string, output any) error {
+	client := c.HTTP
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err := c.wait(ctx); err != nil {
+			return err
+		}
+		req, err := c.request(ctx, endpoint)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+		closeErr := resp.Body.Close()
+		if readErr != nil {
+			return readErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if len(body) > maxResponseBytes {
+			return errors.New("granola public API response exceeds size limit")
+		}
+		if resp.StatusCode == http.StatusTooManyRequests && attempt+1 < maxAttempts {
+			if err := waitForRetry(ctx, retryDelay(resp.Header.Get("Retry-After"), attempt)); err != nil {
+				return err
+			}
+			continue
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return APIError{StatusCode: resp.StatusCode}
+		}
+		if err := json.Unmarshal(body, output); err != nil {
+			return fmt.Errorf("decode public API response: %w", err)
+		}
+		return nil
+	}
+	return APIError{StatusCode: http.StatusTooManyRequests}
+}
+
+func (c *Client) request(ctx context.Context, endpoint string) (*http.Request, error) {
+	base := strings.TrimRight(c.BaseURL, "/")
+	if base == "" {
+		base = BaseURL
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+func (c *Client) wait(ctx context.Context) error {
+	interval := c.RequestInterval
+	if interval == 0 {
+		interval = 200 * time.Millisecond
+	}
+	if interval < 0 {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if remaining := interval - time.Since(c.lastRequest); !c.lastRequest.IsZero() && remaining > 0 {
+		timer := time.NewTimer(remaining)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	c.lastRequest = time.Now()
+	return nil
+}
+
+type APIError struct {
+	StatusCode int
+}
+
+func (e APIError) Error() string {
+	return fmt.Sprintf("granola public API returned %d", e.StatusCode)
+}
+
+func retryDelay(value string, attempt int) time.Duration {
+	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	if when, err := http.ParseTime(value); err == nil {
+		if delay := time.Until(when); delay > 0 {
+			return delay
+		}
+		return 0
+	}
+	return time.Second << attempt
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/publicapi/client_test.go
+++ b/internal/publicapi/client_test.go
@@ -1,0 +1,154 @@
+package publicapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClientPaginatesAndIncludesTranscript(t *testing.T) {
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Fatalf("authorization header = %q", r.Header.Get("Authorization"))
+		}
+		requests = append(requests, r.URL.RequestURI())
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/notes":
+			_, _ = w.Write([]byte(`{"notes":[],"hasMore":false,"cursor":null}`))
+		case "/v1/notes/not_12345678901234":
+			_, _ = w.Write([]byte(`{"id":"not_12345678901234","object":"note","title":null,"created_at":"2026-08-03T01:00:00Z","updated_at":"2026-08-03T02:00:00Z","calendar_event":{},"attendees":[],"folder_membership":[],"summary_text":"","summary_markdown":null,"transcript":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := Client{BaseURL: srv.URL, APIKey: "test-key", RequestInterval: -1}
+	if _, err := client.ListNotes(context.Background(), "next cursor", 30); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.GetNote(context.Background(), "not_12345678901234", true); err != nil {
+		t.Fatal(err)
+	}
+	if len(requests) != 2 || requests[0] != "/v1/notes?cursor=next+cursor&page_size=30" || requests[1] != "/v1/notes/not_12345678901234?include=transcript" {
+		t.Fatalf("requests = %#v", requests)
+	}
+}
+
+func TestClientErrorDoesNotExposeResponseBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"secret":"must-not-leak"}`, http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	client := Client{BaseURL: srv.URL, APIKey: "test-key", RequestInterval: -1}
+	_, err := client.ListNotes(context.Background(), "", 1)
+	if err == nil || strings.Contains(err.Error(), "must-not-leak") {
+		t.Fatalf("unsafe error = %v", err)
+	}
+}
+
+func TestClientRetriesRateLimitWithoutExposingBody(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Retry-After", "0")
+			http.Error(w, `{"secret":"must-not-leak"}`, http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte(`{"notes":[],"hasMore":false,"cursor":null}`))
+	}))
+	defer srv.Close()
+	client := Client{BaseURL: srv.URL, APIKey: "test-key", RequestInterval: -1}
+	if _, err := client.ListNotes(context.Background(), "", 1); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d", requests)
+	}
+}
+
+func TestNormalizersPreserveSummaryAndStableTranscriptIdentity(t *testing.T) {
+	title := "Planning"
+	markdown := "summary"
+	note, err := NoteToModel(Note{
+		ID:              "not_12345678901234",
+		Title:           &title,
+		CreatedAt:       "2026-08-03T01:00:00Z",
+		UpdatedAt:       "2026-08-03T02:00:00Z",
+		SummaryText:     "plain",
+		SummaryMarkdown: &markdown,
+	}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if note.Source != "public-api" || note.SummaryText == nil || *note.SummaryText != "plain" || note.SummaryMarkdown == nil || *note.SummaryMarkdown != "summary" {
+		t.Fatalf("note = %#v", note)
+	}
+	input := Transcript{
+		Speaker:   Speaker{Source: "microphone", Attribution: "me"},
+		Text:      "hello",
+		StartTime: "2026-08-03T01:00:00Z",
+		EndTime:   "2026-08-03T01:00:01Z",
+	}
+	first, err := TranscriptToModel(note.ID, input, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := TranscriptToModel(note.ID, input, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ID == second.ID || first.Source != "microphone" || !first.IsFinal {
+		t.Fatalf("chunks = %#v %#v", first, second)
+	}
+	corrected := input
+	corrected.Text = "corrected"
+	corrected.Speaker.Attribution = "Speaker 1"
+	replacement, err := TranscriptToModel(note.ID, corrected, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacement.ID != first.ID || replacement.PayloadHash == first.PayloadHash {
+		t.Fatalf("corrected chunk identity changed or payload hash did not: %#v %#v", first, replacement)
+	}
+}
+
+func TestLivePublicAPIContract(t *testing.T) {
+	if os.Getenv("GRAINCRAWL_LIVE_PUBLIC_API") != "1" {
+		t.Skip("set GRAINCRAWL_LIVE_PUBLIC_API=1 to run")
+	}
+	key := os.Getenv(KeyEnv)
+	if key == "" {
+		t.Fatal("live public API test requires GRANOLA_PUBLIC_API_KEY")
+	}
+	client := Client{APIKey: key}
+	page, err := client.ListNotes(context.Background(), "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Notes) != 1 || page.Notes[0].ID == "" {
+		t.Fatal("live public API returned no notes")
+	}
+	note, err := client.GetNote(context.Background(), page.Notes[0].ID, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if note.ID != page.Notes[0].ID {
+		t.Fatal("live note detail did not match list identity")
+	}
+	if _, err := NoteToModel(note, time.Now()); err != nil {
+		t.Fatal("live note detail did not normalize")
+	}
+	for occurrence, transcript := range note.Transcript {
+		if _, err := TranscriptToModel(note.ID, transcript, occurrence); err != nil {
+			t.Fatal("live transcript did not normalize")
+		}
+	}
+}

--- a/internal/publicapi/normalize.go
+++ b/internal/publicapi/normalize.go
@@ -1,0 +1,82 @@
+package publicapi
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/openclaw/graincrawl/internal/hashutil"
+	"github.com/openclaw/graincrawl/internal/model"
+	"github.com/openclaw/graincrawl/internal/timeutil"
+)
+
+func NoteToModel(note Note, now time.Time) (model.Note, error) {
+	created, err := timeutil.Parse(note.CreatedAt)
+	if err != nil {
+		return model.Note{}, err
+	}
+	updated, err := timeutil.Parse(note.UpdatedAt)
+	if err != nil {
+		return model.Note{}, err
+	}
+	var calendarEventID *string
+	if note.CalendarEvent.CalendarEventID != "" {
+		calendarEventID = &note.CalendarEvent.CalendarEventID
+	}
+	var summaryText *string
+	if note.SummaryText != "" {
+		summaryText = &note.SummaryText
+	}
+	return model.Note{
+		ID:              note.ID,
+		Title:           note.Title,
+		Type:            "meeting",
+		CreatedAt:       created,
+		UpdatedAt:       updated,
+		CalendarEventID: calendarEventID,
+		SummaryText:     summaryText,
+		SummaryMarkdown: note.SummaryMarkdown,
+		Source:          model.SourcePublicAPI,
+		PayloadHash:     hashutil.JSON(note),
+		LastSeenAt:      now,
+	}, nil
+}
+
+func TranscriptToModel(noteID string, transcript Transcript, occurrence int) (model.TranscriptChunk, error) {
+	start, err := timeutil.Parse(transcript.StartTime)
+	if err != nil {
+		return model.TranscriptChunk{}, err
+	}
+	end, err := timeutil.Parse(transcript.EndTime)
+	if err != nil {
+		return model.TranscriptChunk{}, err
+	}
+	identityHash := TranscriptIdentityHash(transcript)
+	return model.TranscriptChunk{
+		ID:             fmt.Sprintf("public-api:%s:%s:%d", noteID, identityHash, occurrence),
+		DocumentID:     noteID,
+		StartTimestamp: start,
+		EndTimestamp:   end,
+		Source:         transcript.Speaker.Source,
+		IsFinal:        true,
+		Text:           transcript.Text,
+		PayloadHash:    TranscriptHash(transcript),
+	}, nil
+}
+
+func TranscriptHash(transcript Transcript) string {
+	return hashutil.JSON(transcript)
+}
+
+func TranscriptIdentityHash(transcript Transcript) string {
+	return hashutil.JSON(struct {
+		StartTime        string `json:"start_time"`
+		EndTime          string `json:"end_time"`
+		Source           string `json:"source"`
+		DiarizationLabel string `json:"diarization_label"`
+	}{
+		StartTime:        transcript.StartTime,
+		EndTime:          transcript.EndTime,
+		Source:           transcript.Speaker.Source,
+		DiarizationLabel: transcript.Speaker.DiarizationLabel,
+	})
+}

--- a/internal/publicapi/types.go
+++ b/internal/publicapi/types.go
@@ -1,0 +1,66 @@
+package publicapi
+
+type NotesResponse struct {
+	Notes   []NoteSummary `json:"notes"`
+	HasMore bool          `json:"hasMore"`
+	Cursor  *string       `json:"cursor"`
+}
+
+type NoteSummary struct {
+	ID        string  `json:"id"`
+	Object    string  `json:"object"`
+	Title     *string `json:"title"`
+	Owner     Person  `json:"owner"`
+	CreatedAt string  `json:"created_at"`
+	UpdatedAt string  `json:"updated_at"`
+}
+
+type Note struct {
+	ID               string        `json:"id"`
+	Object           string        `json:"object"`
+	Title            *string       `json:"title"`
+	Owner            Person        `json:"owner"`
+	CreatedAt        string        `json:"created_at"`
+	UpdatedAt        string        `json:"updated_at"`
+	WebURL           string        `json:"web_url"`
+	CalendarEvent    CalendarEvent `json:"calendar_event"`
+	Attendees        []Person      `json:"attendees"`
+	FolderMembership []Folder      `json:"folder_membership"`
+	SummaryText      string        `json:"summary_text"`
+	SummaryMarkdown  *string       `json:"summary_markdown"`
+	Transcript       []Transcript  `json:"transcript"`
+}
+
+type Person struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+type CalendarEvent struct {
+	EventTitle         string   `json:"event_title"`
+	Invitees           []Person `json:"invitees"`
+	Organiser          string   `json:"organiser"`
+	CalendarEventID    string   `json:"calendar_event_id"`
+	ScheduledStartTime string   `json:"scheduled_start_time"`
+	ScheduledEndTime   string   `json:"scheduled_end_time"`
+}
+
+type Folder struct {
+	ID             string  `json:"id"`
+	Object         string  `json:"object"`
+	Name           string  `json:"name"`
+	ParentFolderID *string `json:"parent_folder_id"`
+}
+
+type Transcript struct {
+	Speaker   Speaker `json:"speaker"`
+	Text      string  `json:"text"`
+	StartTime string  `json:"start_time"`
+	EndTime   string  `json:"end_time"`
+}
+
+type Speaker struct {
+	Source           string `json:"source"`
+	Attribution      string `json:"attribution,omitempty"`
+	DiarizationLabel string `json:"diarization_label,omitempty"`
+}

--- a/internal/security/report.go
+++ b/internal/security/report.go
@@ -66,9 +66,9 @@ func Sources(cfg config.Config, paths granola.ProfilePaths) []SourceSupport {
 		{
 			Source:      model.SourcePublicAPI,
 			Allowed:     cfg.Granola.AllowPublicAPI,
-			Implemented: false,
+			Implemented: true,
 			NeedsSecret: true,
-			Notes:       "official API is currently limited compared with local archive goals",
+			Notes:       "official read-only API; key is read from GRANOLA_PUBLIC_API_KEY and never persisted",
 		},
 	}
 	if postMigration {
@@ -120,7 +120,7 @@ func Secrets(cfg config.Config) SecretReport {
 		PersistHelperKeys:  cfg.Security.PersistHelperKeys,
 		KeychainPromptMode: cfg.Security.KeychainPromptMode,
 		GranolaKeychain:    "external",
-		Message:            "graincrawl does not persist Granola tokens; encrypted sources require an explicit unlock flow",
+		Message:            "graincrawl does not persist Granola tokens or public API keys; encrypted sources require an explicit unlock flow",
 	}
 }
 

--- a/internal/security/report_test.go
+++ b/internal/security/report_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openclaw/graincrawl/internal/config"
 	"github.com/openclaw/graincrawl/internal/granola"
+	"github.com/openclaw/graincrawl/internal/model"
 )
 
 func TestUnlockReportDoesNotRequireCompanion(t *testing.T) {
@@ -22,6 +23,24 @@ func TestUnlockReportDoesNotRequireCompanion(t *testing.T) {
 	if !report.PromptAllowed || !strings.Contains(report.Message, "explicit unlock") {
 		t.Fatalf("unexpected encrypted JSON unlock report: %#v", report)
 	}
+}
+
+func TestPublicAPISupportIsImplementedAndUnaffectedByLocalEncryption(t *testing.T) {
+	cfg := config.Config{Granola: config.GranolaConfig{AllowPublicAPI: true}}
+	profile := t.TempDir()
+	if err := os.WriteFile(filepath.Join(profile, "cache-v6.json.enc"), []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, source := range Sources(cfg, granola.Paths(profile, "")) {
+		if source.Source != model.SourcePublicAPI {
+			continue
+		}
+		if !source.Allowed || !source.Implemented || !source.NeedsSecret || !strings.Contains(source.Notes, "GRANOLA_PUBLIC_API_KEY") {
+			t.Fatalf("public API support = %#v", source)
+		}
+		return
+	}
+	t.Fatal("public API source missing")
 }
 
 func TestUnlockReportExplainsUnsupportedOPFSWithoutCompanion(t *testing.T) {

--- a/internal/syncer/public_api.go
+++ b/internal/syncer/public_api.go
@@ -1,0 +1,110 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	"github.com/openclaw/graincrawl/internal/config"
+	"github.com/openclaw/graincrawl/internal/model"
+	"github.com/openclaw/graincrawl/internal/publicapi"
+	"github.com/openclaw/graincrawl/internal/store"
+)
+
+var ErrPublicAPIKeyNotFound = errors.New("Granola public API key not found in " + publicapi.KeyEnv)
+
+func PublicAPI(ctx context.Context, cfg config.Config, st *store.Store, opts Options) (Result, error) {
+	key := os.Getenv(publicapi.KeyEnv)
+	if key == "" {
+		return Result{Source: model.SourcePublicAPI}, ErrPublicAPIKeyNotFound
+	}
+	client := &publicapi.Client{
+		APIKey:  key,
+		BaseURL: cfg.API.PublicBaseURL,
+	}
+	return syncPublic(ctx, client, st, opts)
+}
+
+func syncPublic(ctx context.Context, client *publicapi.Client, st *store.Store, opts Options) (Result, error) {
+	source := model.SourcePublicAPI
+	started := time.Now().UTC()
+	result := Result{Source: source}
+	if opts.IncludePanels {
+		result.Message = "official public API does not expose panels or deletion events"
+	} else {
+		result.Message = "official public API does not expose deletion events"
+	}
+
+	cursor := ""
+	for opts.Limit <= 0 || result.Notes < opts.Limit {
+		pageSize := 30
+		if remaining := opts.Limit - result.Notes; opts.Limit > 0 && remaining < pageSize {
+			pageSize = remaining
+		}
+		page, err := client.ListNotes(ctx, cursor, pageSize)
+		if err != nil {
+			return result, err
+		}
+		for _, summary := range page.Notes {
+			note, err := client.GetNote(ctx, summary.ID, opts.IncludeTranscripts)
+			if err != nil {
+				return result, err
+			}
+			now := time.Now().UTC()
+			if err := retainSourceObject(ctx, st, source, "document", note.ID, note.ID, note, now); err != nil {
+				return result, err
+			}
+			modelNote, err := publicapi.NoteToModel(note, now)
+			if err != nil {
+				return result, err
+			}
+			if err := st.UpsertNote(ctx, modelNote); err != nil {
+				return result, err
+			}
+			result.Notes++
+
+			if opts.IncludeTranscripts {
+				occurrences := make(map[string]int)
+				for _, transcript := range note.Transcript {
+					identityHash := publicapi.TranscriptIdentityHash(transcript)
+					occurrence := occurrences[identityHash]
+					occurrences[identityHash] = occurrence + 1
+					modelChunk, err := publicapi.TranscriptToModel(note.ID, transcript, occurrence)
+					if err != nil {
+						return result, err
+					}
+					if err := retainSourceObject(ctx, st, source, "transcript_chunk", modelChunk.ID, note.ID, transcript, now); err != nil {
+						return result, err
+					}
+					if err := st.UpsertTranscriptChunk(ctx, modelChunk); err != nil {
+						return result, err
+					}
+					result.Transcripts++
+				}
+			}
+			if opts.Limit > 0 && result.Notes >= opts.Limit {
+				break
+			}
+		}
+		if !page.HasMore {
+			break
+		}
+		if page.Cursor == nil || *page.Cursor == "" || *page.Cursor == cursor {
+			return result, errors.New("granola public API returned an invalid pagination cursor")
+		}
+		cursor = *page.Cursor
+	}
+
+	completed := time.Now().UTC()
+	_, _ = st.InsertSyncRun(ctx, model.SyncRun{
+		Source:      source,
+		StartedAt:   started,
+		CompletedAt: completed,
+		Status:      "ok",
+		Notes:       result.Notes,
+		Transcripts: result.Transcripts,
+		Message:     result.Message,
+	})
+	return result, nil
+}

--- a/internal/syncer/public_api_test.go
+++ b/internal/syncer/public_api_test.go
@@ -1,0 +1,124 @@
+package syncer
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/graincrawl/internal/config"
+	"github.com/openclaw/graincrawl/internal/model"
+	"github.com/openclaw/graincrawl/internal/publicapi"
+	"github.com/openclaw/graincrawl/internal/store"
+)
+
+func TestSyncPublicArchivesSummariesAndTranscriptsAcrossPages(t *testing.T) {
+	ctx := context.Background()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/notes", func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("cursor") {
+		case "":
+			writeJSON(t, w, `{"notes":[{"id":"not_11111111111111","object":"note","title":"First","owner":{},"created_at":"2026-08-03T01:00:00Z","updated_at":"2026-08-03T02:00:00Z"}],"hasMore":true,"cursor":"next"}`)
+		case "next":
+			writeJSON(t, w, `{"notes":[{"id":"not_22222222222222","object":"note","title":"Second","owner":{},"created_at":"2026-08-03T03:00:00Z","updated_at":"2026-08-03T04:00:00Z"}],"hasMore":false,"cursor":null}`)
+		default:
+			t.Fatalf("unexpected cursor %q", r.URL.Query().Get("cursor"))
+		}
+	})
+	mux.HandleFunc("/v1/notes/not_11111111111111", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("include") != "transcript" {
+			t.Fatalf("include = %q", r.URL.Query().Get("include"))
+		}
+		writeJSON(t, w, `{"id":"not_11111111111111","object":"note","title":"First","owner":{},"created_at":"2026-08-03T01:00:00Z","updated_at":"2026-08-03T02:00:00Z","calendar_event":{"calendar_event_id":"event-1"},"attendees":[],"folder_membership":[],"summary_text":"plain summary","summary_markdown":"## Summary","transcript":[{"speaker":{"source":"microphone","attribution":"me"},"text":"archived transcript","start_time":"2026-08-03T01:00:00Z","end_time":"2026-08-03T01:00:01Z"}]}`)
+	})
+	mux.HandleFunc("/v1/notes/not_22222222222222", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"id":"not_22222222222222","object":"note","title":"Second","owner":{},"created_at":"2026-08-03T03:00:00Z","updated_at":"2026-08-03T04:00:00Z","calendar_event":{},"attendees":[],"folder_membership":[],"summary_text":"","summary_markdown":null,"transcript":[]}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	client := &publicapi.Client{BaseURL: srv.URL, APIKey: "test-key", RequestInterval: -1}
+	result, err := syncPublic(ctx, client, st, Options{Limit: 2, IncludeTranscripts: true, IncludePanels: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Source != model.SourcePublicAPI || result.Notes != 2 || result.Transcripts != 1 || result.Panels != 0 || !strings.Contains(result.Message, "does not expose panels") {
+		t.Fatalf("result = %#v", result)
+	}
+	note, ok, err := st.GetNote(ctx, "not_11111111111111")
+	if err != nil || !ok {
+		t.Fatalf("note: ok=%v err=%v", ok, err)
+	}
+	if note.Source != model.SourcePublicAPI || note.SummaryMarkdown == nil || *note.SummaryMarkdown != "## Summary" || note.CalendarEventID == nil || *note.CalendarEventID != "event-1" {
+		t.Fatalf("note = %#v", note)
+	}
+	chunks, err := st.ListTranscript(ctx, note.ID)
+	if err != nil || len(chunks) != 1 || chunks[0].Text != "archived transcript" {
+		t.Fatalf("chunks = %#v err=%v", chunks, err)
+	}
+	objects, err := st.ListSourceObjects(ctx, "", 10)
+	if err != nil || len(objects) != 3 {
+		t.Fatalf("source objects = %#v err=%v", objects, err)
+	}
+}
+
+func TestRunPublicRequiresExplicitEnableAndEnvironmentKey(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	cfg := config.Config{Granola: config.GranolaConfig{AllowPublicAPI: false}}
+	if _, err := Run(ctx, cfg, st, Options{Source: model.SourcePublicAPI}); err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Fatalf("disabled error = %v", err)
+	}
+	cfg.Granola.AllowPublicAPI = true
+	t.Setenv(publicapi.KeyEnv, "")
+	if _, err := Run(ctx, cfg, st, Options{Source: model.SourcePublicAPI}); err != ErrPublicAPIKeyNotFound {
+		t.Fatalf("missing key error = %v", err)
+	}
+}
+
+func TestRunPublicIgnoresEncryptedLocalGranolaState(t *testing.T) {
+	ctx := context.Background()
+	profile := t.TempDir()
+	if err := os.WriteFile(filepath.Join(profile, "cache-v6.json.enc"), []byte("encrypted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"notes":[],"hasMore":false,"cursor":null}`)
+	}))
+	defer srv.Close()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	t.Setenv(publicapi.KeyEnv, "test-key")
+	cfg := config.Config{
+		Granola: config.GranolaConfig{
+			ProfilePath:     profile,
+			AllowPublicAPI:  true,
+			PreferredSource: string(model.SourcePublicAPI),
+		},
+		API:  config.APIConfig{PublicBaseURL: srv.URL},
+		Sync: config.SyncConfig{DefaultLimit: 100},
+	}
+	result, err := Run(ctx, cfg, st, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Source != model.SourcePublicAPI || result.Notes != 0 {
+		t.Fatalf("result = %#v", result)
+	}
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -29,6 +29,11 @@ func Run(ctx context.Context, cfg config.Config, st *store.Store, opts Options) 
 		if !cfg.Granola.AllowPrivateAPI {
 			return Result{}, fmt.Errorf("private-api source disabled in config")
 		}
+	case model.SourcePublicAPI:
+		if !cfg.Granola.AllowPublicAPI {
+			return Result{}, fmt.Errorf("public-api source disabled in config")
+		}
+		return PublicAPI(ctx, cfg, st, opts)
 	case model.SourceDesktopCache:
 		if !cfg.Granola.AllowDesktopCache {
 			return Result{}, fmt.Errorf("desktop-cache source disabled in config")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where graincrawl users on Granola 7.427+ could lose local archive refresh capability when the desktop app moved its encryption key behind an app-scoped macOS Keychain boundary.

## Why This Change Was Made

Adds an explicit adapter for Granola's official read-only public API. The source is disabled by default, reads its scoped key only from `GRANOLA_PUBLIC_API_KEY`, respects documented pagination and rate limits, archives summaries and optional transcripts, and does not infer deletions or claim panel support.

## User Impact

Users with a supported Granola API key can restore read-only archive sync without accessing or weakening the desktop app sandbox. The key is never persisted by graincrawl.

## Evidence

- `make check`
- opt-in live public API contract test passed through 1Password runtime injection
- live test validated list, note detail, summary normalization, and transcript normalization without logging content or writing an archive
- post-migration fixture proves `public-api` remains independent of encrypted local Granola state
- secret/path scrub completed before push
