### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.4.0 - 2026-08-03
+
 - Add an explicit official Granola public API source for scoped read-only note,
   summary, and transcript archiving without depending on the desktop app's
   local encryption key.


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-blocking validation failure where the `v0.4.0` workflow could not extract dated release notes from the changelog.

## Why This Change Was Made

Moves the two shipped changes under one dated `v0.4.0` heading while retaining an empty `Unreleased` section for future work.

## User Impact

No runtime behavior changes. Maintainers can publish the already-validated public API release.

## Evidence

- exact release heading validation reproduced locally
- `git diff --check`
