### PR TITLE
build: move Go floor to 1.26.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ With Homebrew:
 brew install openclaw/tap/graincrawl
 ```
 
-From source (Go 1.26.5 or newer):
+From source (Go 1.26.6 or newer):
 
 ```bash
 go install github.com/openclaw/graincrawl/cmd/graincrawl@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/graincrawl
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/openclaw/crawlkit v0.14.6


### PR DESCRIPTION
## Summary

- move the module Go floor and source-install requirement from 1.26.5 to 1.26.6
- clear GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218

## Proof

- `GOTOOLCHAIN=go1.26.6 go build ./...`
- `GOTOOLCHAIN=go1.26.6 go test ./...`
- `GOTOOLCHAIN=go1.26.6 GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...` reported no vulnerabilities
- built and executed `cmd/graincrawl` with Go 1.26.6; `--version` completed successfully
- autoreview clean with no accepted or actionable findings
