### PR TITLE
fix(privateapi): cap response bodies at 64MiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- Cap private API response bodies at 64MiB, matching the public API client.
-
 ## v0.4.1 - 2026-08-14
 
 - Update the minimum Go toolchain to 1.26.6 to resolve GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Cap private API response bodies at 64MiB, matching the public API client.
+
 ## v0.4.1 - 2026-08-14
 
 - Update the minimum Go toolchain to 1.26.6 to resolve GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.

--- a/internal/privateapi/client.go
+++ b/internal/privateapi/client.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
 )
 
-const BaseURL = "https://api.granola.ai"
+const (
+	BaseURL          = "https://api.granola.ai"
+	maxResponseBytes = 64 << 20
+)
 
 type Client struct {
 	HTTP          *http.Client
@@ -58,9 +62,12 @@ func (c Client) Do(ctx context.Context, endpoint string, input any, output any) 
 		return err
 	}
 	defer resp.Body.Close()
-	b, err := io.ReadAll(resp.Body)
+	b, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
 		return err
+	}
+	if len(b) > maxResponseBytes {
+		return errors.New("granola private API response exceeds size limit")
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return APIError{StatusCode: resp.StatusCode, Body: string(b)}

--- a/internal/privateapi/client_test.go
+++ b/internal/privateapi/client_test.go
@@ -1,10 +1,13 @@
 package privateapi
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -25,6 +28,33 @@ func TestClientSendsGranolaHeaders(t *testing.T) {
 	}
 	if gotAuth != "Bearer token" || gotWorkspace != "workspace" {
 		t.Fatalf("headers auth=%q workspace=%q", gotAuth, gotWorkspace)
+	}
+}
+
+func TestClientRejectsOversizedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"docs":[],"deleted":[],"pad":"`)
+		chunk := bytes.Repeat([]byte("a"), 1024*1024)
+		written := 0
+		for written <= maxResponseBytes {
+			n, err := w.Write(chunk)
+			if err != nil {
+				return
+			}
+			written += n
+		}
+		_, _ = io.WriteString(w, `"}`)
+	}))
+	defer srv.Close()
+
+	client := Client{BaseURL: srv.URL, AccessToken: "token"}
+	_, err := client.GetDocuments(context.Background(), DocumentsRequest{})
+	if err == nil {
+		t.Fatal("expected oversized private API response to be rejected")
+	}
+	if !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("expected size limit error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Granola private API client used unbounded `io.ReadAll` on `resp.Body`. The public API sibling already caps responses at 64 MiB. A large private response can OOM `graincrawl sync`.

## Evidence

```console
Red:  go test ./internal/privateapi/ -run TestClientRejectsOversizedResponse
      FAIL: expected oversized private API response to be rejected
Green: same test ok
```

## Real behavior proof
Behavior addressed: Private API responses larger than 64 MiB are rejected instead of being fully buffered.
Real environment tested: macOS, Go from the worktree, graincrawl `/tmp/oc-impl-graincrawl` head `a962f1b`.
Exact steps or command run after this patch: `GOWORK=off go test ./internal/privateapi/ -run TestClientRejectsOversizedResponse`
Evidence after fix: red/green recorded above.
Observed result after fix: httptest body over 64 MiB returns `granola private API response exceeds size limit`.
What was not tested: A live granola.ai payload near the cap.
