### PR TITLE
fix(publicapi): cap Granola Retry-After waits

### DIFF
--- a/internal/publicapi/client.go
+++ b/internal/publicapi/client.go
@@ -20,6 +20,9 @@ const (
 	pageLimit        = 30
 	maxResponseBytes = 64 << 20
 	maxAttempts      = 4
+	// maxRetryAfter caps Retry-After waits. Granola may send delta-seconds
+	// or an HTTP-date far in the future; CLI sync often has no deadline.
+	maxRetryAfter = 60 * time.Second
 )
 
 type Client struct {
@@ -147,15 +150,23 @@ func (e APIError) Error() string {
 
 func retryDelay(value string, attempt int) time.Duration {
 	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
-		return time.Duration(seconds) * time.Second
+		return capRetryAfter(time.Duration(seconds) * time.Second)
 	}
 	if when, err := http.ParseTime(value); err == nil {
 		if delay := time.Until(when); delay > 0 {
-			return delay
+			return capRetryAfter(delay)
 		}
 		return 0
 	}
 	return time.Second << attempt
+}
+
+func capRetryAfter(wait time.Duration) time.Duration {
+	if wait > maxRetryAfter {
+		return maxRetryAfter
+	}
+
+	return wait
 }
 
 func waitForRetry(ctx context.Context, delay time.Duration) error {

--- a/internal/publicapi/client_test.go
+++ b/internal/publicapi/client_test.go
@@ -74,6 +74,21 @@ func TestClientRetriesRateLimitWithoutExposingBody(t *testing.T) {
 	}
 }
 
+func TestRetryDelayCapsDeltaSecondsAndHTTPDate(t *testing.T) {
+	if got := retryDelay("86400", 0); got != 60*time.Second {
+		t.Fatalf("retryDelay(86400) = %s, want 60s", got)
+	}
+
+	when := time.Now().Add(24 * time.Hour).UTC().Format(http.TimeFormat)
+	if got := retryDelay(when, 0); got != 60*time.Second {
+		t.Fatalf("retryDelay(%q) = %s, want 60s", when, got)
+	}
+
+	if got := retryDelay("5", 0); got != 5*time.Second {
+		t.Fatalf("retryDelay(5) = %s, want 5s", got)
+	}
+}
+
 func TestNormalizersPreserveSummaryAndStableTranscriptIdentity(t *testing.T) {
 	title := "Planning"
 	markdown := "summary"


### PR DESCRIPTION
## What Problem This Solves

Granola 429 `Retry-After` values were used as-is. A 86400s header, or an HTTP-date a day in the future, parked `graincrawl sync` for hours. The CLI often uses a context with no deadline.

## Why

`retryDelay` returned parsed delta-seconds and HTTP-dates with no upper bound. `waitForRetry` then sleeps that duration. Same class as gitcrawl #155 and notcrawl #111.

## User Impact

A single oversized `Retry-After` can stall a public-API sync until the process is killed. After this change the wait is at most 60s per attempt.

## Evidence

Live `go run` of the same parse-and-cap logic:

```console
$ go run /tmp/sibling-proof/gc-retry-live.go
retryDelay(86400)=1m0s
retryDelay(HTTP-date +24h)=1m0s
retryDelay(5)=5s
```

## Real behavior proof

- **Behavior or issue addressed:** Uncapped Retry-After (delta-seconds or HTTP-date) could sleep graincrawl public-API retries for hours.
- **Real environment tested:** macOS, Go 1.25, worktree `/tmp/gc-retry-after-cap` at current HEAD, live `go run` of the parse-and-cap helper.
- **Exact steps or command run after this patch:**

  ```bash
  go run /tmp/sibling-proof/gc-retry-live.go
  ```

- **Evidence after fix:** terminal output from the live helper:

  ```console
  $ go run /tmp/sibling-proof/gc-retry-live.go
  retryDelay(86400)=1m0s
  retryDelay(HTTP-date +24h)=1m0s
  retryDelay(5)=5s
  ```

- **Observed result after fix:** A 86400s header and a +24h HTTP-date both cap at 60s. A 5s header still waits 5s.
- **What was not tested:** A live Granola 429 with a real oversized Retry-After header.

## Change

- `internal/publicapi/client.go`: cap parsed Retry-After waits at 60s
- `internal/publicapi/client_test.go`: cover 86400s and a +24h HTTP-date
