### PR TITLE
fix(syncer): surface private-api transcript and panel fetch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-**Highlights:** Safer snapshot imports and bounded API responses and retry waits.
+**Highlights:** Private API sync now fails instead of reporting success when Granola data cannot be fetched, alongside safer snapshot imports and bounded API responses and retry waits.
 
+- Report private API transcript and panel fetch failures instead of recording incomplete syncs as successful; retain earlier writes for a later retry. Thanks @SebTardif.
 - Reject absolute and parent-traversing snapshot shard paths through CrawlKit v0.14.9. Thanks @SebTardif.
 - Cap private API response bodies at 64 MiB to prevent oversized responses from exhausting memory. Thanks @SebTardif.
 - Cap public API rate-limit waits at 60 seconds, including oversized numeric and HTTP-date `Retry-After` headers, without overflowing the delay. Thanks @SebTardif.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,6 +33,8 @@ graincrawl [--json] [--config <path>] [--version] <command> [args]
 
 `private-api`, `public-api`, and `desktop-cache` are supported sync sources. `public-api` must be explicitly enabled with `allow_public_api = true` or `GRAINCRAWL_ALLOW_PUBLIC_API=true`; its key is read only from `GRANOLA_PUBLIC_API_KEY`. It archives notes, summaries, and transcripts available to the key, but the official API does not expose panels or deletion events.
 
+Private API sync stops and exits nonzero if an enabled transcript or panel fetch fails. It does not record a successful sync run. Writes completed before the error remain in the archive; later documents and the deletion feed are not processed. Rerun the same sync after the upstream failure clears to finish hydration and process deletions. Existing records are updated by identity rather than duplicated. Successful empty responses are valid, and `--no-transcripts` or `--no-panels` skips the corresponding fetch entirely.
+
 Public API rate-limit responses are retried up to three times. Each `Retry-After` wait is capped at 60 seconds, so a distant retry date or oversized delay cannot stall sync for hours.
 
 ## Read the archive

--- a/internal/syncer/private_api.go
+++ b/internal/syncer/private_api.go
@@ -103,47 +103,49 @@ func syncPrivateWithMessage(ctx context.Context, client privateapi.Client, st *s
 		result.Notes++
 		if opts.IncludeTranscripts {
 			chunks, err := client.GetDocumentTranscript(ctx, doc.ID)
-			if err == nil {
-				for _, chunk := range chunks {
-					if err := retainSourceObject(ctx, st, source, "transcript_chunk", chunk.ID, doc.ID, chunk, now); err != nil {
-						return result, err
-					}
-					modelChunk, err := privateapi.TranscriptToModel(chunk)
-					if err != nil {
-						return result, err
-					}
-					if err := st.UpsertTranscriptChunk(ctx, modelChunk); err != nil {
-						return result, err
-					}
-					result.Transcripts++
+			if err != nil {
+				return result, err
+			}
+			for _, chunk := range chunks {
+				if err := retainSourceObject(ctx, st, source, "transcript_chunk", chunk.ID, doc.ID, chunk, now); err != nil {
+					return result, err
 				}
+				modelChunk, err := privateapi.TranscriptToModel(chunk)
+				if err != nil {
+					return result, err
+				}
+				if err := st.UpsertTranscriptChunk(ctx, modelChunk); err != nil {
+					return result, err
+				}
+				result.Transcripts++
 			}
 		}
 		if opts.IncludePanels {
 			panels, err := client.GetDocumentPanels(ctx, doc.ID)
-			if err == nil {
-				for _, panel := range panels {
-					if err := retainSourceObject(ctx, st, source, "panel", panel.ID, doc.ID, panel, now); err != nil {
-						return result, err
-					}
-					modelPanel, err := privateapi.PanelToModel(panel)
-					if err != nil {
-						return result, err
-					}
-					if err := st.UpsertPanel(ctx, modelPanel); err != nil {
-						return result, err
-					}
-					if modelPanel.DeletedAt != nil {
-						if err := st.TombstoneSourceObject(ctx, source, "panel", panel.ID, store.Deletion{
-							At:     *modelPanel.DeletedAt,
-							Source: source,
-							Reason: store.DeletionReasonSourceField,
-						}); err != nil {
-							return result, err
-						}
-					}
-					result.Panels++
+			if err != nil {
+				return result, err
+			}
+			for _, panel := range panels {
+				if err := retainSourceObject(ctx, st, source, "panel", panel.ID, doc.ID, panel, now); err != nil {
+					return result, err
 				}
+				modelPanel, err := privateapi.PanelToModel(panel)
+				if err != nil {
+					return result, err
+				}
+				if err := st.UpsertPanel(ctx, modelPanel); err != nil {
+					return result, err
+				}
+				if modelPanel.DeletedAt != nil {
+					if err := st.TombstoneSourceObject(ctx, source, "panel", panel.ID, store.Deletion{
+						At:     *modelPanel.DeletedAt,
+						Source: source,
+						Reason: store.DeletionReasonSourceField,
+					}); err != nil {
+						return result, err
+					}
+				}
+				result.Panels++
 			}
 		}
 		if note.DeletedAt != nil {

--- a/internal/syncer/private_api_test.go
+++ b/internal/syncer/private_api_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -193,6 +194,68 @@ func TestSyncPrivateRetainsUnknownExplicitDeleteAsStubTombstone(t *testing.T) {
 	assertDeletion(t, "stub note", note.DeletedAt, note.DeletionSource, note.DeletionReason)
 }
 
+func TestSyncPrivateReturnsTranscriptFetchError(t *testing.T) {
+	ctx := context.Background()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/get-documents", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"docs":[{"id":"doc-1","type":"meeting","created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:01:00Z"}],"deleted":[],"shared":[]}`)
+	})
+	mux.HandleFunc("/v1/get-documents-batch", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"docs":[]}`)
+	})
+	mux.HandleFunc("/v1/get-document-transcript", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream timeout", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	client := privateapi.Client{BaseURL: srv.URL, AccessToken: "token"}
+	_, err = syncPrivateWithMessage(ctx, client, st, Options{IncludeTranscripts: true}, false, "")
+	if err == nil {
+		t.Fatal("expected transcript fetch error")
+	}
+	if !strings.Contains(err.Error(), "granola api returned 500") {
+		t.Fatalf("error = %v", err)
+	}
+	assertNoOKSyncRun(t, ctx, st)
+}
+
+func TestSyncPrivateReturnsPanelFetchError(t *testing.T) {
+	ctx := context.Background()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/get-documents", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"docs":[{"id":"doc-1","type":"meeting","created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:01:00Z"}],"deleted":[],"shared":[]}`)
+	})
+	mux.HandleFunc("/v1/get-documents-batch", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"docs":[]}`)
+	})
+	mux.HandleFunc("/v1/get-document-panels", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream timeout", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	client := privateapi.Client{BaseURL: srv.URL, AccessToken: "token"}
+	_, err = syncPrivateWithMessage(ctx, client, st, Options{IncludePanels: true}, false, "")
+	if err == nil {
+		t.Fatal("expected panel fetch error")
+	}
+	if !strings.Contains(err.Error(), "granola api returned 500") {
+		t.Fatalf("error = %v", err)
+	}
+	assertNoOKSyncRun(t, ctx, st)
+}
+
 func TestSyncPrivateRetainsPanelDeletedAtOnPanelAndSourceObject(t *testing.T) {
 	ctx := context.Background()
 	mux := http.NewServeMux()
@@ -230,6 +293,19 @@ func TestSyncPrivateRetainsPanelDeletedAtOnPanelAndSourceObject(t *testing.T) {
 	}
 	if objects[0].DeletedAt == nil || objects[0].DeletionReason != store.DeletionReasonSourceField {
 		t.Fatalf("panel source deletion = %#v", objects[0])
+	}
+}
+
+func assertNoOKSyncRun(t *testing.T, ctx context.Context, st *store.Store) {
+	t.Helper()
+	runs, err := st.ListSyncRuns(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, run := range runs {
+		if run.Status == "ok" {
+			t.Fatalf("sync run recorded as ok after fetch error: %#v", run)
+		}
 	}
 }
 

--- a/internal/syncer/private_api_test.go
+++ b/internal/syncer/private_api_test.go
@@ -2,11 +2,13 @@ package syncer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -293,6 +295,84 @@ func TestSyncPrivateRetainsPanelDeletedAtOnPanelAndSourceObject(t *testing.T) {
 	}
 	if objects[0].DeletedAt == nil || objects[0].DeletionReason != store.DeletionReasonSourceField {
 		t.Fatalf("panel source deletion = %#v", objects[0])
+	}
+}
+
+func TestSyncPrivateHydrationFailureRetainsWritesAndCanRetry(t *testing.T) {
+	for _, endpoint := range []string{"/v1/get-document-transcript", "/v1/get-document-panels"} {
+		t.Run(endpoint, func(t *testing.T) {
+			ctx := context.Background()
+			var failing atomic.Bool
+			failing.Store(true)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if failing.Load() && r.URL.Path == endpoint {
+					http.Error(w, "upstream unavailable", http.StatusInternalServerError)
+					return
+				}
+				var req struct {
+					DocumentID string `json:"document_id"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Errorf("decode request: %v", err)
+					http.Error(w, "invalid request", http.StatusBadRequest)
+					return
+				}
+				switch r.URL.Path {
+				case "/v2/get-documents":
+					writeJSON(t, w, `{"docs":[{"id":"doc-1","type":"meeting"},{"id":"doc-2","type":"meeting"}],"deleted":["deleted-doc"],"shared":[]}`)
+				case "/v1/get-documents-batch":
+					writeJSON(t, w, `{"docs":[]}`)
+				case "/v1/get-document-transcript":
+					writeJSON(t, w, fmt.Sprintf(`[{"id":"chunk-%s","document_id":"%s","text":"retained transcript","is_final":true}]`, req.DocumentID, req.DocumentID))
+				case "/v1/get-document-panels":
+					writeJSON(t, w, fmt.Sprintf(`[{"id":"panel-%s","document_id":"%s","title":"Summary","content":{"text":"retained panel"}}]`, req.DocumentID, req.DocumentID))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+			st, err := store.Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer st.Close()
+			client := privateapi.Client{BaseURL: srv.URL, AccessToken: "token"}
+			opts := Options{IncludeTranscripts: true, IncludePanels: true}
+			result, err := syncPrivateWithMessage(ctx, client, st, opts, false, "")
+			if err == nil || !strings.Contains(err.Error(), "granola api returned 500") || result.Notes != 1 {
+				t.Fatalf("failed sync = %#v, error = %v", result, err)
+			}
+			assertNoOKSyncRun(t, ctx, st)
+			for _, id := range []string{"doc-1", "doc-2", "deleted-doc"} {
+				_, ok, err := st.GetNote(ctx, id)
+				if err != nil || ok != (id == "doc-1") {
+					t.Fatalf("note %s after failure: exists=%v err=%v", id, ok, err)
+				}
+			}
+			failing.Store(false)
+			result, err = syncPrivateWithMessage(ctx, client, st, opts, false, "")
+			if err != nil || result.Notes != 2 || result.Transcripts != 2 || result.Panels != 2 || result.Deleted != 1 {
+				t.Fatalf("retry = %#v, error = %v", result, err)
+			}
+			for _, id := range []string{"doc-1", "doc-2"} {
+				chunks, err := st.ListTranscript(ctx, id)
+				if err != nil || len(chunks) != 1 {
+					t.Fatalf("%s transcripts after retry = %#v, err=%v", id, chunks, err)
+				}
+				panels, err := st.ListPanels(ctx, id)
+				if err != nil || len(panels) != 1 {
+					t.Fatalf("%s panels after retry = %#v, err=%v", id, panels, err)
+				}
+			}
+			deleted, ok, err := st.GetNote(ctx, "deleted-doc")
+			if err != nil || !ok || deleted.DeletedAt == nil {
+				t.Fatalf("deletion after retry: %#v exists=%v err=%v", deleted, ok, err)
+			}
+			runs, err := st.ListSyncRuns(ctx, 10)
+			if err != nil || len(runs) != 1 || runs[0].Status != "ok" {
+				t.Fatalf("sync runs after retry = %#v, err=%v", runs, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Private-API sync must not report a complete archive after an enabled transcript or panel fetch fails. Return those errors through the existing CLI failure path, retaining earlier writes for a later retry.

Peter approved this fail-fast default. A failure exits nonzero and records no successful sync run. Earlier writes remain; later documents and deletion processing are deferred until recovery. Retrying updates children by identity without duplicates. Successful empty responses and the existing skip flags remain valid. Document-batch errors are addressed by stacked PR #91.

Rebased onto `main` after #93 (`1e6eae93aac3712c15805bcacf0f2a2d13f15430`). Contributor implementation and recovery coverage are retained. The credited changelog entry now sits directly below the expanded Highlights sentence, before the snapshot-import entry.

Validation on `618dfe3ada130e9588e43d6091070aeb34fd2881`:

- `make check` passed, including module/vulnerability checks, formatting, static analysis, full tests, CLI smoke, and macOS/Linux snapshot packaging.
- `GOWORK=off go test -race -count=1 ./...` passed.
- The actual built CLI against a synthetic loopback HTTPS API changes transcript/panel HTTP 500 cases from exit 0 with one successful run on main to exit 1 with zero successful runs. One note remains after failure. A healthy retry completes both notes, both sets of children, and the deletion; no duplicate children, and search/SQLite integrity pass.
- Empty responses and `--no-transcripts --no-panels` succeed; skipped endpoints are never requested.
- Committed-branch Codex autoreview is scoped-clean through P2.
- All four GitHub CI jobs passed on this exact head: https://github.com/openclaw/graincrawl/actions/runs/33987905216.

No production Granola data, credentials, or Keychain changes were used. Contributor: @SebTardif.
