### PR TITLE
fix(publicapi): bound rate-limit waits without duration overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Cap public API rate-limit waits at 60 seconds, including oversized numeric and HTTP-date `Retry-After` headers, without overflowing the delay. Thanks @SebTardif.
 - Update Go to 1.27.0, refresh SQLite and terminal/runtime dependencies, and update GoReleaser, vulnerability/dead-code tooling, and TruffleHog.
 
 ## v0.4.1 - 2026-08-14

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,6 +33,8 @@ graincrawl [--json] [--config <path>] [--version] <command> [args]
 
 `private-api`, `public-api`, and `desktop-cache` are supported sync sources. `public-api` must be explicitly enabled with `allow_public_api = true` or `GRAINCRAWL_ALLOW_PUBLIC_API=true`; its key is read only from `GRANOLA_PUBLIC_API_KEY`. It archives notes, summaries, and transcripts available to the key, but the official API does not expose panels or deletion events.
 
+Public API rate-limit responses are retried up to three times. Each `Retry-After` wait is capped at 60 seconds, so a distant retry date or oversized delay cannot stall sync for hours.
+
 ## Read the archive
 
 | Command | Purpose |

--- a/internal/publicapi/client.go
+++ b/internal/publicapi/client.go
@@ -150,7 +150,11 @@ func (e APIError) Error() string {
 
 func retryDelay(value string, attempt int) time.Duration {
 	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
-		return capRetryAfter(time.Duration(seconds) * time.Second)
+		// Clamp seconds first so the duration conversion cannot overflow.
+		if seconds > int(maxRetryAfter/time.Second) {
+			return maxRetryAfter
+		}
+		return time.Duration(seconds) * time.Second
 	}
 	if when, err := http.ParseTime(value); err == nil {
 		if delay := time.Until(when); delay > 0 {

--- a/internal/publicapi/client.go
+++ b/internal/publicapi/client.go
@@ -20,6 +20,9 @@ const (
 	pageLimit        = 30
 	maxResponseBytes = 64 << 20
 	maxAttempts      = 4
+	// maxRetryAfter caps Retry-After waits. Granola may send delta-seconds
+	// or an HTTP-date far in the future; CLI sync often has no deadline.
+	maxRetryAfter = 60 * time.Second
 )
 
 type Client struct {
@@ -147,15 +150,23 @@ func (e APIError) Error() string {
 
 func retryDelay(value string, attempt int) time.Duration {
 	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
-		return time.Duration(seconds) * time.Second
+		return capRetryAfter(time.Duration(seconds) * time.Second)
 	}
 	if when, err := http.ParseTime(value); err == nil {
 		if delay := time.Until(when); delay > 0 {
-			return delay
+			return capRetryAfter(delay)
 		}
 		return 0
 	}
 	return time.Second << attempt
+}
+
+func capRetryAfter(wait time.Duration) time.Duration {
+	if wait > maxRetryAfter {
+		return maxRetryAfter
+	}
+
+	return wait
 }
 
 func waitForRetry(ctx context.Context, delay time.Duration) error {

--- a/internal/publicapi/client_test.go
+++ b/internal/publicapi/client_test.go
@@ -74,6 +74,21 @@ func TestClientRetriesRateLimitWithoutExposingBody(t *testing.T) {
 	}
 }
 
+func TestRetryDelayCapsDeltaSecondsAndHTTPDate(t *testing.T) {
+	if got := retryDelay("86400", 0); got != 60*time.Second {
+		t.Fatalf("retryDelay(86400) = %s, want 60s", got)
+	}
+
+	when := time.Now().Add(24 * time.Hour).UTC().Format(http.TimeFormat)
+	if got := retryDelay(when, 0); got != 60*time.Second {
+		t.Fatalf("retryDelay(%q) = %s, want 60s", when, got)
+	}
+
+	if got := retryDelay("5", 0); got != 5*time.Second {
+		t.Fatalf("retryDelay(5) = %s, want 5s", got)
+	}
+}
+
 func TestNormalizersPreserveSummaryAndStableTranscriptIdentity(t *testing.T) {
 	title := "Planning"
 	markdown := "summary"

--- a/internal/publicapi/client_test.go
+++ b/internal/publicapi/client_test.go
@@ -2,9 +2,11 @@ package publicapi
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -75,8 +77,25 @@ func TestClientRetriesRateLimitWithoutExposingBody(t *testing.T) {
 }
 
 func TestRetryDelayCapsDeltaSecondsAndHTTPDate(t *testing.T) {
-	if got := retryDelay("86400", 0); got != 60*time.Second {
-		t.Fatalf("retryDelay(86400) = %s, want 60s", got)
+	for _, tt := range []struct {
+		value string
+		want  time.Duration
+	}{
+		{"0", 0},
+		{"5", 5 * time.Second},
+		{"60", 60 * time.Second},
+		{"61", 60 * time.Second},
+		{"86400", 60 * time.Second},
+		{strconv.Itoa(math.MaxInt), 60 * time.Second},
+		{"-1", 4 * time.Second},
+		{"invalid", 4 * time.Second},
+		{"", 4 * time.Second},
+	} {
+		t.Run(tt.value, func(t *testing.T) {
+			if got := retryDelay(tt.value, 2); got != tt.want {
+				t.Fatalf("retryDelay(%q) = %s, want %s", tt.value, got, tt.want)
+			}
+		})
 	}
 
 	when := time.Now().Add(24 * time.Hour).UTC().Format(http.TimeFormat)
@@ -84,8 +103,9 @@ func TestRetryDelayCapsDeltaSecondsAndHTTPDate(t *testing.T) {
 		t.Fatalf("retryDelay(%q) = %s, want 60s", when, got)
 	}
 
-	if got := retryDelay("5", 0); got != 5*time.Second {
-		t.Fatalf("retryDelay(5) = %s, want 5s", got)
+	past := time.Now().Add(-time.Hour).UTC().Format(http.TimeFormat)
+	if got := retryDelay(past, 0); got != 0 {
+		t.Fatalf("retryDelay(%q) = %s, want 0s", past, got)
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running public-API sync could wait for hours after a distant `Retry-After` header, or retry immediately when a large numeric header overflowed a duration.

## Why This Change Was Made

Cap each rate-limit wait at 60 seconds. Clamp numeric seconds before duration conversion and cap HTTP-date delays after parsing. Preserve normal delays, zero, past dates, and malformed-header backoff. Document the limit and cover the numeric boundary.

This is the maintainer completion of https://github.com/openclaw/graincrawl/pull/87, retaining @SebTardif's original commit and adding the overflow fix and production CLI proof. The original can be closed as superseded after this lands. Thanks @SebTardif.

## User Impact

Public-API sync waits at most 60 seconds per rate-limit retry, including the largest parseable numeric header. The existing three-retry limit remains in effect.

## Evidence

The regression failed on the contributor head with:

```text
retryDelay("9223372036854775807") = -1s, want 1m0s
```

Built the real CLI using `GOWORK=off go build -o graincrawl ./cmd/graincrawl` and ran it against a loopback HTTPS CONNECT fixture. The fixture terminates only synthetic Granola requests, responds with one 429 followed by a successful empty note list, and records the interval between requests. Each CLI process has temporary config, profile, and SQLite paths, a temporary test certificate, and synthetic credentials. Production code is unmodified for the fixture; no real Granola account or data is used.

Repaired-candidate commands (the fixture and logs are retained for the maintainer handoff):

```bash
GOWORK=off go build -o /private/tmp/graincrawl-triage-20260830-l0JFcQ/fixed-graincrawl ./cmd/graincrawl
python3 /private/tmp/graincrawl-triage-20260830-l0JFcQ/prove_cli.py /private/tmp/graincrawl-triage-20260830-l0JFcQ/fixed-graincrawl retry --timeout 90
GOWORK=off go test ./internal/publicapi -run TestRetryDelayCapsDeltaSecondsAndHTTPDate -count=1
make check
```

The fixture launches the real `graincrawl --config <temporary-config> --json sync --source public-api` command. Before-fix runs use a 10-second cutoff to avoid the original day-long wait.

Observed request-to-request intervals:

| Header | Main / original PR | Repaired CLI |
|---|---|---|
| `86400` | Main still waiting at 10s | 60.01s, exit 0, two requests, one `ok` run |
| `9223372036854775807` | 0.13s immediate retry on both heads | 60.01s, exit 0, two requests, one `ok` run |
| HTTP-date +24h | Main still waiting at 10s | 60.00s, exit 0, two requests, one `ok` run |
| `1` | 1.00–1.01s | 1.00s, exit 0, two requests, one `ok` run |

Codex autoreview: scoped clean at the default P0 threshold. This proves the actual CLI/client scheduling and archive result against a controlled HTTPS server; it does not claim an oversized 429 was observed from the live Granola service.

Every validation component in `make check` reported success: module verification/tidy, govulncheck (no vulnerabilities found), formatting, vet/deadcode, all tests, isolated CLI smoke, and credential-free snapshot builds for Darwin/Linux on amd64/arm64 with `.deb`/`.rpm` packaging. [CI run 33365922621](https://github.com/openclaw/graincrawl/actions/runs/33365922621) is green on commit `816ae7d54175ef2509b2c625a88ef79651363e33`; CodeQL and secret scanning also passed. No CI retries were needed.

Local tooling note: after GoReleaser printed `release succeeded after 1m59s` and exited, its outer `go run` wrapper remained in filesystem cleanup for several minutes. That task-owned wrapper was stopped, so the aggregate local `make check` command ended interrupted during post-run cleanup. All validation components had already succeeded; the complete CI run above finished normally.
