### PR TITLE
chore(deps): update CrawlKit to v0.14.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bound release-check HTTP requests to 30 seconds through CrawlKit v0.14.8 so an unresponsive server cannot hang update checks indefinitely.
 - Cap public API rate-limit waits at 60 seconds, including oversized numeric and HTTP-date `Retry-After` headers, without overflowing the delay. Thanks @SebTardif.
 - Update Go to 1.27.0, refresh SQLite and terminal/runtime dependencies, and update GoReleaser, vulnerability/dead-code tooling, and TruffleHog.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -78,6 +78,8 @@ Legacy encrypted JSON requires `allow_encrypted_json = true` and an explicit unl
 
 The public API key is never written to graincrawl config or SQLite. Inject it at runtime, for example with `op run --env-file <template> -- graincrawl sync --source public-api`.
 
+Release-check HTTP requests time out after 30 seconds if the server does not respond.
+
 ## JSON and automation
 
 Every command that returns data accepts the global `--json` option. For example:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openclaw/graincrawl
 go 1.27.0
 
 require (
-	github.com/openclaw/crawlkit v0.14.7
+	github.com/openclaw/crawlkit v0.14.8
 	github.com/pelletier/go-toml/v2 v2.4.3
 	modernc.org/sqlite v1.57.0
 )

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.7 h1:Kvceob5WyEtrGt4YkwKRcepU77g7FX/HPTRIiCe+ArQ=
-github.com/openclaw/crawlkit v0.14.7/go.mod h1:iDnctBAFtqB5l2sHREfpyjQwifToeebDVdVJvZWVLn0=
+github.com/openclaw/crawlkit v0.14.8 h1:JdmvIcfznzGGDNczACtktebd0ueLWaTrCwW8ZPtm7Fg=
+github.com/openclaw/crawlkit v0.14.8/go.mod h1:7QxbJgGm6ZQAiBXyWSR+U6Eyt8p4pMcC7zjY0h3GKjY=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=


### PR DESCRIPTION
## What Problem This Solves

Release checks can hang indefinitely when GitHub stops responding. Updating CrawlKit picks up its default 30-second HTTP timeout.

## Why This Change Was Made

Update `github.com/openclaw/crawlkit` from `v0.14.7` to [`v0.14.8`](https://github.com/openclaw/crawlkit/releases/tag/v0.14.8), regenerate module checksums with Go, and document the timeout in the command reference and changelog.

`GOWORK=off go get -u -t ./...` followed by `go mod tidy` produced this single module update. All 34 direct and indirect requirements in `go.mod` are now current on their module paths. No dependencies were added or removed, and no major upgrades were taken or deferred. Unused upstream test/tool modules visible in the broader module graph were not promoted into new root requirements.

The Go toolchain, GoReleaser, govulncheck, deadcode, and workflow dependencies were checked against current upstream releases. Existing floating major tags already select the current Actions versions; the exact GoReleaser Action, TruffleHog, and GitHub App token pins are current. The reusable release workflow remains on its documented compatible `v1` contract.

## User Impact

Unresponsive release-check HTTP requests time out after 30 seconds. The timeout is owned by CrawlKit and automatically applies to Graincrawl's existing release-check calls.

## Evidence

`make check` passed on Go 1.27.0 / macOS arm64, including module verification/tidiness, govulncheck, formatting, vet, deadcode, the full uncached test suite, CLI smoke, and credential-free snapshot packaging for Linux/macOS amd64/arm64 plus DEB/RPM packages. Output excerpts:

```text
$ make check
all modules verified
No vulnerabilities found.
ok  	github.com/openclaw/graincrawl/internal/cli	2.783s
ok  	github.com/openclaw/graincrawl/internal/publicapi	2.397s
ok  	github.com/openclaw/graincrawl/internal/store	4.805s
ok  	github.com/openclaw/graincrawl/internal/syncer	5.631s
  • release succeeded after 16s
```

The last line is GoReleaser's local snapshot result with `--snapshot --clean --skip=publish`; nothing was published.

Codex autoreview completed with `scoped-clean`, no accepted/actionable findings at the requested default P0 threshold.

### Built CLI live proof

Built the actual CLI with `make build VERSION=0.0.0-proof`, using a synthetic build version so the release check performs a real request rather than skipping a development build. Each invocation ran with `env -i`, isolated HOME/XDG/config/database/profile paths, and no credentials. The archive input was a synthetic cache containing one note and one transcript; no personal Granola data was read. The final command fetched real public GitHub release metadata without using a cache.

Exact CLI commands and output:

```text
$ ./bin/graincrawl --json sync --source desktop-cache
{
  "ok": true,
  "result": {
    "source": "desktop-cache",
    "notes": 1,
    "transcripts": 1,
    "panels": 0,
    "deleted": 0
  }
}

$ ./bin/graincrawl --json sql select\ count\(\*\)\ as\ notes\ from\ notes
{
  "ok": true,
  "result": {
    "columns": [
      "notes"
    ],
    "rows": [
      [
        "1"
      ]
    ]
  }
}

$ ./bin/graincrawl --json check-update --force
{
  "ok": true,
  "result": {
    "checked_at": "2026-08-31T02:32:48.129097-07:00",
    "current_version": "0.0.0-proof",
    "latest_version": "v0.4.1",
    "latest_url": "https://github.com/openclaw/graincrawl/releases/tag/v0.4.1",
    "update_available": true,
    "from_cache": false
  }
}
```

`search decision`, `transcripts get proof-note`, Markdown export, and portable snapshot creation also completed successfully against the populated synthetic archive.

### CI reasoning

Default-branch build/test CI was already green at `ea733c1`: [CI run](https://github.com/openclaw/graincrawl/actions/runs/33367080580). [CodeQL](https://github.com/openclaw/graincrawl/actions/runs/33367080484) and [secret scanning](https://github.com/openclaw/graincrawl/actions/runs/33367080457) were also green. No CI assertions, tests, or jobs were weakened.

The `CI` workflow contains the build/test/dependency/lint/snapshot gates. CodeQL and secret scanning are security gates. Stale handling, assignment, ClawSweeper dispatch, and release drafting are repository operations; manual release, tap, asset verification, and Crabbox hydration workflows are separate from build/test CI and were not dispatched.

PR validation is green at `e614385`: [CI (deps, lint, test, snapshot)](https://github.com/openclaw/graincrawl/actions/runs/33378316596), [CodeQL](https://github.com/openclaw/graincrawl/actions/runs/33378316683), and [secret scanning](https://github.com/openclaw/graincrawl/actions/runs/33378316554). All passed on the first run. Default-branch CI remains green at `ea733c1`. The PR is left open for the orchestrator to review and land.
