### PR TITLE
fix(privateapi): fail sync when document batch hydrate errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Highlights:** Private API sync now fails instead of reporting success when Granola data cannot be fetched, alongside safer snapshot imports and bounded API responses and retry waits.
 
+- Preserve archived note bodies and fail sync when private API document batch hydration fails, instead of reporting a successful list-only archive. Thanks @SebTardif.
 - Report private API transcript and panel fetch failures instead of recording incomplete syncs as successful; retain earlier writes for a later retry. Thanks @SebTardif.
 - Reject absolute and parent-traversing snapshot shard paths through CrawlKit v0.14.9. Thanks @SebTardif.
 - Cap private API response bodies at 64 MiB to prevent oversized responses from exhausting memory. Thanks @SebTardif.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,6 +33,8 @@ graincrawl [--json] [--config <path>] [--version] <command> [args]
 
 `private-api`, `public-api`, and `desktop-cache` are supported sync sources. `public-api` must be explicitly enabled with `allow_public_api = true` or `GRAINCRAWL_ALLOW_PUBLIC_API=true`; its key is read only from `GRANOLA_PUBLIC_API_KEY`. It archives notes, summaries, and transcripts available to the key, but the official API does not expose panels or deletion events.
 
+Private API document batch hydration must succeed before notes are written. A failed batch request stops sync with a nonzero exit and no successful sync-run record; the deletion feed is also deferred. Existing archived notes stay unchanged, though workspace metadata may already have been retained. A successful empty batch response keeps the listed documents. Rerun sync after the upstream failure clears.
+
 Private API sync stops and exits nonzero if an enabled transcript or panel fetch fails. It does not record a successful sync run. Writes completed before the error remain in the archive; later documents and the deletion feed are not processed. Rerun the same sync after the upstream failure clears to finish hydration and process deletions. Existing records are updated by identity rather than duplicated. Successful empty responses are valid, and `--no-transcripts` or `--no-panels` skips the corresponding fetch entirely.
 
 Public API rate-limit responses are retried up to three times. Each `Retry-After` wait is capped at 60 seconds, so a distant retry date or oversized delay cannot stall sync for hours.

--- a/internal/syncer/private_api.go
+++ b/internal/syncer/private_api.go
@@ -81,7 +81,11 @@ func syncPrivateWithMessage(ctx context.Context, client privateapi.Client, st *s
 	if opts.Limit > 0 && len(all) > opts.Limit {
 		all = all[:opts.Limit]
 	}
-	if hydrated, err := client.GetDocumentsBatch(ctx, documentIDs(all)); err == nil && len(hydrated.Docs) > 0 {
+	hydrated, err := client.GetDocumentsBatch(ctx, documentIDs(all))
+	if err != nil {
+		return result, err
+	}
+	if len(hydrated.Docs) > 0 {
 		all = mergeHydratedDocuments(all, hydrated.Docs)
 	}
 	now := time.Now().UTC()

--- a/internal/syncer/private_api_test.go
+++ b/internal/syncer/private_api_test.go
@@ -55,12 +55,18 @@ func TestSyncPrivateHydratesDocumentBodyBeforeUpsert(t *testing.T) {
 
 func TestSyncPrivateFailsWhenBatchHydrateErrors(t *testing.T) {
 	ctx := context.Background()
+	var failing atomic.Bool
+	failing.Store(true)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v2/get-documents", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(t, w, `{"docs":[{"id":"doc-1","title":"Planning","type":"meeting","created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:01:00Z"}],"deleted":[],"shared":[]}`)
+		writeJSON(t, w, `{"docs":[{"id":"doc-1","title":"Planning","type":"meeting","created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:01:00Z"}],"deleted":["deleted-doc"],"shared":[]}`)
 	})
 	mux.HandleFunc("/v1/get-documents-batch", func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, `{"error":"hydrate failed"}`, http.StatusInternalServerError)
+		if failing.Load() {
+			http.Error(w, `{"error":"hydrate failed"}`, http.StatusInternalServerError)
+			return
+		}
+		writeJSON(t, w, `{"docs":[]}`)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -71,8 +77,40 @@ func TestSyncPrivateFailsWhenBatchHydrateErrors(t *testing.T) {
 	}
 	defer st.Close()
 	client := privateapi.Client{BaseURL: srv.URL, AccessToken: "token"}
-	if _, err := syncPrivateWithMessage(ctx, client, st, Options{Source: model.SourcePrivateAPI, Limit: 1}, false, ""); err == nil {
-		t.Fatal("expected sync to fail when document batch hydrate returns 500")
+	opts := Options{Source: model.SourcePrivateAPI, Limit: 1}
+	result, err := syncPrivateWithMessage(ctx, client, st, opts, false, "")
+	if err == nil || !strings.Contains(err.Error(), "granola api returned 500") || result.Notes != 0 {
+		t.Fatalf("failed sync = %#v, error = %v", result, err)
+	}
+	for _, id := range []string{"doc-1", "deleted-doc"} {
+		if _, ok, err := st.GetNote(ctx, id); err != nil || ok {
+			t.Fatalf("note %s after batch failure: exists=%v err=%v", id, ok, err)
+		}
+	}
+	objects, err := st.ListSourceObjects(ctx, "", 10)
+	if err != nil || len(objects) != 0 {
+		t.Fatalf("source objects after batch failure = %#v, err=%v", objects, err)
+	}
+	runs, err := st.ListSyncRuns(ctx, 10)
+	if err != nil || len(runs) != 0 {
+		t.Fatalf("sync runs after batch failure = %#v, err=%v", runs, err)
+	}
+	failing.Store(false)
+	result, err = syncPrivateWithMessage(ctx, client, st, opts, false, "")
+	if err != nil || result.Notes != 1 || result.Deleted != 1 {
+		t.Fatalf("retry = %#v, error = %v", result, err)
+	}
+	note, ok, err := st.GetNote(ctx, "doc-1")
+	if err != nil || !ok || note.Title == nil || *note.Title != "Planning" {
+		t.Fatalf("listed document after empty batch retry: %#v exists=%v err=%v", note, ok, err)
+	}
+	deleted, ok, err := st.GetNote(ctx, "deleted-doc")
+	if err != nil || !ok || deleted.DeletedAt == nil {
+		t.Fatalf("deletion after retry: %#v exists=%v err=%v", deleted, ok, err)
+	}
+	runs, err = st.ListSyncRuns(ctx, 10)
+	if err != nil || len(runs) != 1 || runs[0].Status != "ok" {
+		t.Fatalf("sync runs after retry = %#v, err=%v", runs, err)
 	}
 }
 

--- a/internal/syncer/private_api_test.go
+++ b/internal/syncer/private_api_test.go
@@ -114,6 +114,38 @@ func TestSyncPrivateFailsWhenBatchHydrateErrors(t *testing.T) {
 	}
 }
 
+func TestSyncPrivateBatchFailurePreservesArchivedBody(t *testing.T) {
+	ctx := context.Background()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/get-documents", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"docs":[{"id":"doc-1","title":"Thin list document","type":"meeting"}],"deleted":[],"shared":[]}`)
+	})
+	mux.HandleFunc("/v1/get-documents-batch", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	title, body := "Archived document", "Previously hydrated note body"
+	if err := st.UpsertNote(ctx, model.Note{ID: "doc-1", Type: "meeting", Title: &title, NotesMarkdown: &body}); err != nil {
+		t.Fatal(err)
+	}
+	client := privateapi.Client{BaseURL: srv.URL, AccessToken: "token"}
+	result, syncErr := syncPrivateWithMessage(ctx, client, st, Options{}, false, "")
+	note, ok, err := st.GetNote(ctx, "doc-1")
+	if err != nil || !ok || note.NotesMarkdown == nil || *note.NotesMarkdown != body || note.Title == nil || *note.Title != title {
+		t.Fatalf("batch failure replaced archived note: %#v, exists=%v, err=%v", note, ok, err)
+	}
+	if syncErr == nil || !strings.Contains(syncErr.Error(), "granola api returned 500") || result.Notes != 0 {
+		t.Fatalf("failed sync = %#v, error = %v", result, syncErr)
+	}
+	assertNoOKSyncRun(t, ctx, st)
+}
+
 func TestSyncPrivateConsumesExplicitDeleteFeedAndTombstonesChildren(t *testing.T) {
 	ctx := context.Background()
 	deleted := false

--- a/internal/syncer/private_api_test.go
+++ b/internal/syncer/private_api_test.go
@@ -53,6 +53,29 @@ func TestSyncPrivateHydratesDocumentBodyBeforeUpsert(t *testing.T) {
 	}
 }
 
+func TestSyncPrivateFailsWhenBatchHydrateErrors(t *testing.T) {
+	ctx := context.Background()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/get-documents", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, `{"docs":[{"id":"doc-1","title":"Planning","type":"meeting","created_at":"2026-05-06T10:00:00Z","updated_at":"2026-05-06T10:01:00Z"}],"deleted":[],"shared":[]}`)
+	})
+	mux.HandleFunc("/v1/get-documents-batch", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"hydrate failed"}`, http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "graincrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	client := privateapi.Client{BaseURL: srv.URL, AccessToken: "token"}
+	if _, err := syncPrivateWithMessage(ctx, client, st, Options{Source: model.SourcePrivateAPI, Limit: 1}, false, ""); err == nil {
+		t.Fatal("expected sync to fail when document batch hydrate returns 500")
+	}
+}
+
 func TestSyncPrivateConsumesExplicitDeleteFeedAndTombstonesChildren(t *testing.T) {
 	ctx := context.Background()
 	deleted := false


### PR DESCRIPTION
A private-API document batch failure must stop sync before thin list documents overwrite an archive. Return the existing batch error before note writes or deletion processing, preserving previously archived bodies and avoiding misleading successful runs.

Peter approved this fail-fast default. Workspace metadata may already be retained, but existing notes remain unchanged when the batch request fails. Successful empty batch responses still retain listed documents. A healthy retry completes hydration and deletions.

Rebased directly onto current main `46d0b700c2b64f0fe4b72553e4a1c079c6264c16`, after #88 was squash-merged. Only the three batch-failure commits remain ahead of main; the already-squashed #88 commits are no longer replayed. The final tree is identical to the previously validated stack, preserving both the child-fetch regressions and the archived-body regression. Both credited correctness entries remain directly beneath Highlights, before CrawlKit.

Validation on `5d368bb24c2044bc1cf5a79fae945512fe5dd614`:

- `make check` passed, including module/vulnerability checks, formatting, static analysis, full tests, CLI smoke, and macOS/Linux snapshot packaging.
- `GOWORK=off go test -race -count=1 ./...` passed, including both sets of regressions.
- The actual built CLI reports commit `5d368bb`. Against a synthetic loopback HTTPS API, batch HTTP 500 exits 1 with zero notes and zero successful runs on a fresh archive, issuing only list and batch requests. On an existing archive, archived titles/bodies and the successful-run count remain unchanged.
- Healthy retries hydrate both notes, process deletion, refresh an existing body, and pass search/SQLite integrity without duplicate notes. Successful empty batches still succeed.
- Committed-branch Codex autoreview is scoped-clean through P2.
- All four GitHub CI jobs passed on the revised head: https://github.com/openclaw/graincrawl/actions/runs/33988652308.

No production Granola data, credentials, or Keychain changes were used. Contributor: @SebTardif.
