### PR TITLE
chore(deps): update CrawlKit for safer snapshot imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
-- Update Go to 1.27.1, SQLite to 3.53.4 through modernc.org/sqlite v1.58.0, terminal width handling, and TruffleHog secret scanning.
-- Bound release-check HTTP requests to 30 seconds through CrawlKit v0.14.8 so an unresponsive server cannot hang update checks indefinitely.
+**Highlights:** Safer snapshot imports and bounded API responses and retry waits.
+
+- Reject absolute and parent-traversing snapshot shard paths through CrawlKit v0.14.9. Thanks @SebTardif.
+- Cap private API response bodies at 64 MiB to prevent oversized responses from exhausting memory. Thanks @SebTardif.
 - Cap public API rate-limit waits at 60 seconds, including oversized numeric and HTTP-date `Retry-After` headers, without overflowing the delay. Thanks @SebTardif.
-- Update Go to 1.27.0, refresh SQLite and terminal/runtime dependencies, and update GoReleaser, vulnerability/dead-code tooling, and TruffleHog.
+- Bound release-check HTTP requests to 30 seconds so an unresponsive server cannot hang update checks indefinitely.
+- Update Go to 1.27.1, SQLite to 3.53.4 through modernc.org/sqlite v1.58.0, terminal/runtime dependencies, GoReleaser, vulnerability/dead-code tooling, and TruffleHog secret scanning.
 
 ## v0.4.1 - 2026-08-14
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -62,6 +62,8 @@ The TUI detail pane is assembled from the SQLite archive, including note text, t
 
 Merge imports keep existing local payloads on identity conflicts and preserve tombstones found on either side.
 
+Snapshot shard paths must be relative to the snapshot directory. Imports reject absolute paths and paths that traverse outside that directory.
+
 ## Security and diagnostics
 
 | Command | Purpose |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openclaw/graincrawl
 go 1.27.1
 
 require (
-	github.com/openclaw/crawlkit v0.14.8
+	github.com/openclaw/crawlkit v0.14.9
 	github.com/pelletier/go-toml/v2 v2.4.3
 	modernc.org/sqlite v1.58.0
 )

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.8 h1:JdmvIcfznzGGDNczACtktebd0ueLWaTrCwW8ZPtm7Fg=
-github.com/openclaw/crawlkit v0.14.8/go.mod h1:7QxbJgGm6ZQAiBXyWSR+U6Eyt8p4pMcC7zjY0h3GKjY=
+github.com/openclaw/crawlkit v0.14.9 h1:nlLxcBvwtgVw5WehmjQCrRyfIYrDyQbJ3zPyKhUeta0=
+github.com/openclaw/crawlkit v0.14.9/go.mod h1:jGtyzzrIcBPzj0fTiP2I+/LcfTMsfT/o9Zx8jh0HMDc=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=


### PR DESCRIPTION
CrawlKit v0.14.9 rejects absolute and parent-traversing snapshot shard paths before reading them. Update Graincrawl to consume that fix and document the import boundary. Keep SQLite's libc at v1.75.6, the version paired with its generated bindings; upstream explicitly warns against independent libc upgrades.

Reconcile `Unreleased` against v0.4.1: lead with safer imports, restore the omitted 64 MiB private-API response-limit entry with contributor credit, and consolidate the repeated runtime/tooling updates. This prepares a patch release; the private-sync default-policy proposals in #88 and #91 remain separate decisions.

Validation on `c952172c078ae64f44dfbcee5b9e6136e800a722`:

- Full Go test suite, formatting, vet, deadcode, and isolated CLI smoke passed. Module verification/tidy and govulncheck passed with no vulnerabilities.
- Built CLI with synthetic desktop-cache data: sync, snapshot create/import from `.`, idempotent merge, exact restore, search, Markdown export, and SQLite integrity passed.
- Built CLI rejects both absolute and parent-traversing shard paths in merge and replace modes; the populated destination archive remains unchanged after every rejection.
- Local and committed-branch Codex autoreview are scoped clean through P2.
- Full `make check`, including macOS/Linux snapshot archives and `.deb`/`.rpm` packages, passed. All four CI jobs passed on the exact head: https://github.com/openclaw/graincrawl/actions/runs/33987357485. Secret scanning and CodeQL passed.

No production Granola data or credentials were used. No tag or release was created.
