### PR TITLE
chore: release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.2 - 2026-09-05
 
 **Highlights:** Private API sync now fails instead of reporting success when Granola data cannot be fetched, alongside safer snapshot imports and bounded API responses and retry waits.
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -36,7 +36,7 @@ make release
 gh workflow run release-unified.yml --repo openclaw/graincrawl -f version=X.Y.Z
 ```
 
-The pipeline freezes an annotated `v0.3.3` tag, runs the GoReleaser matrix,
+The pipeline freezes an annotated `v<version>` tag, runs the GoReleaser matrix,
 signs every Darwin binary as
 `org.openclaw.graincrawl.graincrawl` with
 `Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)`, notarizes the
@@ -57,8 +57,8 @@ RPM workflows download their package type from the published tag and verify
 each package against the pipeline's `SHA256SUMS` before upload:
 
 ```bash
-gh workflow run publish-apt.yml -f tag_name=v0.3.3
-gh workflow run publish-rpm.yml -f tag_name=v0.3.3
+gh workflow run publish-apt.yml -f tag_name=v0.4.2
+gh workflow run publish-rpm.yml -f tag_name=v0.4.2
 ```
 
 ## Legacy Manual Tools
@@ -99,12 +99,12 @@ path.
 If Cloudsmith publishing needs to be retried after the GitHub release exists:
 
 ```bash
-gh workflow run publish-apt.yml -f tag_name=v0.3.3
-gh workflow run publish-rpm.yml -f tag_name=v0.3.3
+gh workflow run publish-apt.yml -f tag_name=v0.4.2
+gh workflow run publish-rpm.yml -f tag_name=v0.4.2
 ```
 
 If the unified Homebrew handoff needs a manual fallback:
 
 ```bash
-gh workflow run homebrew-tap.yml -f tag_name=v0.3.3
+gh workflow run homebrew-tap.yml -f tag_name=v0.4.2
 ```


### PR DESCRIPTION
Prepare the authorized 0.4.2 patch release by dating the existing changelog section and refreshing distribution examples. Preserve Highlights, contributor credit, and the fail-fast sync fixes before the snapshot/dependency entries.

The release workflow accepts this dated heading and injects the tag version into the binary. No runtime behavior or development version defaults change. Codex autoreview is scoped-clean through P2; full make check passed, including snapshot packaging. The built CLI reports version 0.4.2 and commit 203a0de.

This branch carries the exact release commit so the required status checks can pass before advancing protected main and dispatching the unified signed/notarized release.
