### PR TITLE
fix: preserve authoritative notes and stable Markdown exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Preserve private API notes during desktop-cache fallback and reject older updates from the same source without losing deletion evidence.
+- Include a stable note-ID digest in Markdown filenames to prevent same-title exports overwriting one another; existing export files are not removed.
+- Include archived summaries in Markdown exports and human-readable `note get` output.
+
 ## 0.4.2 - 2026-09-05
 
 **Highlights:** Private API sync now fails instead of reporting success when Granola data cannot be fetched, alongside safer snapshot imports and bounded API responses and retry waits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Allow deletion-only placeholders to acquire archived content while retaining note and child tombstones and normal precedence for populated notes.
 - Preserve private API notes during desktop-cache fallback and reject older updates from the same source without losing deletion evidence.
 - Include a stable note-ID digest in Markdown filenames to prevent same-title exports overwriting one another; existing export files are not removed.
 - Include archived summaries in Markdown exports and human-readable `note get` output.

--- a/internal/cli/archive.go
+++ b/internal/cli/archive.go
@@ -108,11 +108,17 @@ func printNote(w io.Writer, note model.Note) {
 	if text := stringValue(note.NotesMarkdown); text != "" {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, text)
-		return
-	}
-	if text := stringValue(note.NotesPlain); text != "" {
+	} else if text := stringValue(note.NotesPlain); text != "" {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, text)
+	}
+	summary := stringValue(note.SummaryMarkdown)
+	if summary == "" {
+		summary = stringValue(note.SummaryText)
+	}
+	if summary != "" {
+		fmt.Fprintln(w, "\nSummary")
+		fmt.Fprintln(w, summary)
 	}
 }
 

--- a/internal/cli/summary_test.go
+++ b/internal/cli/summary_test.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/graincrawl/internal/model"
+)
+
+func TestPrintNoteSummary(t *testing.T) {
+	markdown, plain, body := "**summary**", "plain summary", "notes body"
+	for _, note := range []model.Note{
+		{SummaryText: &plain},
+		{NotesMarkdown: &body, SummaryMarkdown: &markdown, SummaryText: &plain},
+		{NotesPlain: &body},
+	} {
+		var out bytes.Buffer
+		printNote(&out, note)
+		text := out.String()
+		if note.NotesMarkdown != nil || note.NotesPlain != nil {
+			if !strings.Contains(text, body) {
+				t.Fatal("lost notes")
+			}
+		}
+		if note.SummaryMarkdown != nil {
+			if !strings.Contains(text, markdown) || strings.Contains(text, plain) {
+				t.Fatal("summary preference lost")
+			}
+		} else if note.SummaryText != nil && !strings.Contains(text, plain) {
+			t.Fatal("plain summary missing")
+		} else if note.SummaryText == nil && strings.Contains(text, "Summary") {
+			t.Fatal("empty summary section")
+		}
+	}
+}

--- a/internal/exporter/identity_test.go
+++ b/internal/exporter/identity_test.go
@@ -1,0 +1,68 @@
+package exporter
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/graincrawl/internal/model"
+	"github.com/openclaw/graincrawl/internal/store"
+)
+
+func TestMarkdownDistinctStableOutputsAndSummary(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	titles := []string{"Standup", "Standup", "a/b", "a?b", strings.Repeat("x", 81) + "a", strings.Repeat("x", 81) + "b"}
+	summary := "Archived public summary"
+	empty := ""
+	for i, title := range titles {
+		note := model.Note{ID: "note/" + string(rune('a'+i)), Type: "meeting", Title: &title, CreatedAt: now.Add(time.Duration(i) * time.Second), UpdatedAt: now, LastSeenAt: now, Source: model.SourcePublicAPI, SummaryText: &summary}
+		if i%2 == 0 {
+			note.SummaryMarkdown = &empty
+		}
+		if err := st.UpsertNote(ctx, note); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out := t.TempDir()
+	unrelated := filepath.Join(out, "unrelated.md")
+	if err := os.WriteFile(unrelated, []byte("untouched"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first, err := Markdown(ctx, st, out, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Markdown(ctx, st, out, 100)
+	if err != nil || !reflect.DeepEqual(first, second) || first.Count != len(titles) {
+		t.Fatalf("unstable result: %+v %+v %v", first, second, err)
+	}
+	seen := map[string]bool{}
+	for _, path := range first.Files {
+		if seen[path] || filepath.Dir(path) != out {
+			t.Fatalf("duplicate or escaping path: %q", path)
+		}
+		seen[path] = true
+		raw, err := os.ReadFile(path)
+		if err != nil || !strings.Contains(string(raw), "## Summary\n\n"+summary) {
+			t.Fatalf("missing summary: %s %v", raw, err)
+		}
+	}
+	raw, err := os.ReadFile(unrelated)
+	if err != nil || string(raw) != "untouched" {
+		t.Fatalf("unrelated output modified: %v", err)
+	}
+	entries, err := os.ReadDir(out)
+	if err != nil || len(entries) != len(titles)+1 {
+		t.Fatalf("file count: %d %v", len(entries), err)
+	}
+}

--- a/internal/exporter/markdown.go
+++ b/internal/exporter/markdown.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -30,8 +31,19 @@ func Markdown(ctx context.Context, st *store.Store, outDir string, limit int) (M
 		return MarkdownResult{}, err
 	}
 	result := MarkdownResult{OutDir: outDir}
-	for _, note := range notes {
-		path := filepath.Join(outDir, noteFilename(note))
+	paths := make([]string, len(notes))
+	seen := make(map[string]bool, len(notes))
+	for i, note := range notes {
+		name := noteFilename(note)
+		key := strings.ToLower(name)
+		if seen[key] {
+			return MarkdownResult{}, fmt.Errorf("duplicate Markdown output filename")
+		}
+		seen[key] = true
+		paths[i] = filepath.Join(outDir, name)
+	}
+	for i, note := range notes {
+		path := paths[i]
 		if err := os.WriteFile(path, []byte(renderNote(ctx, st, note)), 0o600); err != nil {
 			return MarkdownResult{}, err
 		}
@@ -53,6 +65,11 @@ func renderNote(ctx context.Context, st *store.Store, note model.Note) string {
 		b.WriteString("\n\n")
 	} else if text := valueOr(note.NotesPlain, ""); text != "" {
 		b.WriteString(text)
+		b.WriteString("\n\n")
+	}
+	if summary := valueOr(note.SummaryMarkdown, valueOr(note.SummaryText, "")); summary != "" {
+		b.WriteString("## Summary\n\n")
+		b.WriteString(summary)
 		b.WriteString("\n\n")
 	}
 	if chunks, err := st.ListTranscript(ctx, note.ID); err == nil && len(chunks) > 0 {
@@ -81,7 +98,7 @@ func renderNote(ctx context.Context, st *store.Store, note model.Note) string {
 func noteFilename(note model.Note) string {
 	title := safeFilename(valueOr(note.Title, note.ID))
 	date := note.CreatedAt.Format("2006-01-02")
-	return fmt.Sprintf("%s-%s.md", date, title)
+	return fmt.Sprintf("%s-%s-%x.md", date, title, sha256.Sum256([]byte(note.ID)))
 }
 
 var filenameCleaner = regexp.MustCompile(`[^A-Za-z0-9._-]+`)

--- a/internal/store/note_priority_test.go
+++ b/internal/store/note_priority_test.go
@@ -2,12 +2,148 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/openclaw/graincrawl/internal/model"
 )
+
+func TestNoteDeletionStubHydration(t *testing.T) {
+	for _, source := range []model.Source{model.SourceDesktopCache, model.SourceEncryptedJSON, model.SourcePrivateAPI} {
+		t.Run(string(source), func(t *testing.T) {
+			ctx := context.Background()
+			st, err := Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer st.Close()
+			deleted := time.Date(2026, 9, 8, 12, 0, 0, 123, time.UTC)
+			if err := st.TombstoneDocument(ctx, "note", Deletion{
+				At: deleted, Source: model.SourcePrivateAPI, Reason: DeletionReasonExplicitFeed,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := st.UpsertTranscriptChunk(ctx, model.TranscriptChunk{
+				ID: "chunk", DocumentID: "note", StartTimestamp: deleted,
+				EndTimestamp: deleted.Add(time.Second), Source: "mic", Text: "retained child",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := st.UpsertPanel(ctx, model.Panel{
+				ID: "panel", DocumentID: "note", CreatedAt: deleted, Source: model.SourcePrivateAPI,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := st.UpsertSourceObject(ctx, SourceObject{
+				Source: model.SourcePrivateAPI, Kind: "document", SourceID: "raw",
+				DocumentID: "note", PayloadJSON: `{}`, PayloadHash: "hash", ObservedAt: deleted,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			assertTombstones := func() {
+				t.Helper()
+				for _, table := range []string{"notes", "transcript_chunks", "document_panels", "source_objects"} {
+					var count int
+					query := fmt.Sprintf(`SELECT count(*) FROM %s
+						WHERE deleted_at = ? AND deletion_source = ? AND deletion_reason = ?`, table)
+					if err := st.DB().QueryRowContext(ctx, query, deleted.Format(time.RFC3339Nano),
+						string(model.SourcePrivateAPI), DeletionReasonExplicitFeed).Scan(&count); err != nil {
+						t.Fatal(err)
+					}
+					if count != 1 {
+						t.Fatalf("%s lost its original tombstone", table)
+					}
+				}
+			}
+			assertTombstones()
+			body, summary := "recovered content", "recovered summary"
+			note := model.Note{
+				ID: "note", Type: "meeting", Source: source, PayloadHash: "content-hash",
+				CreatedAt: deleted.Add(-2 * time.Hour), UpdatedAt: deleted.Add(-time.Hour),
+				LastSeenAt: deleted.Add(time.Hour), NotesPlain: &body, SummaryText: &summary,
+			}
+			if err := st.UpsertNote(ctx, note); err != nil {
+				t.Fatal(err)
+			}
+			got, found, err := st.GetNote(ctx, note.ID)
+			if err != nil || !found {
+				t.Fatalf("hydrated note: found=%t err=%v", found, err)
+			}
+			want := note
+			want.DeletedAt, want.DeletionSource, want.DeletionReason = &deleted, string(model.SourcePrivateAPI), DeletionReasonExplicitFeed
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("hydration changed content or deletion provenance: got=%+v want=%+v", got, want)
+			}
+			assertTombstones()
+
+			// Once populated, normal content freshness and source precedence apply.
+			for _, nextSource := range []model.Source{source, model.SourceDesktopCache} {
+				incoming := note
+				incoming.Source = nextSource
+				incoming.UpdatedAt = note.UpdatedAt.Add(-time.Hour)
+				if source == model.SourcePrivateAPI && nextSource == model.SourceDesktopCache {
+					incoming.UpdatedAt = deleted.Add(2 * time.Hour)
+				}
+				replacement := "must not replace recovered content"
+				incoming.NotesPlain = &replacement
+				if err := st.UpsertNote(ctx, incoming); err != nil {
+					t.Fatal(err)
+				}
+				after, _, err := st.GetNote(ctx, note.ID)
+				if err != nil || !reflect.DeepEqual(after, want) {
+					t.Fatalf("populated note lost precedence: %+v err=%v", after, err)
+				}
+				assertTombstones()
+			}
+		})
+	}
+}
+
+func TestNotePrecedenceDoesNotTreatEmptyContentAsDeletionStub(t *testing.T) {
+	for _, change := range []string{
+		"title = ''", "status = ''", "workspace_id = ''", "calendar_event_id = ''",
+		"notes_plain = ''", "notes_markdown = ''", "summary_text = ''", "summary_markdown = ''",
+		"payload_hash = ''", "type = 'meeting'", "updated_at = '2026-09-08T11:00:00Z'",
+		"created_at = '2026-09-08T11:00:00Z'", "last_seen_at = '2026-09-08T13:00:00Z'",
+		"deletion_source = 'other'", "deletion_reason = NULL", "deleted_at = NULL",
+	} {
+		t.Run(change, func(t *testing.T) {
+			ctx := context.Background()
+			st, err := Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer st.Close()
+			now := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+			if err := st.TombstoneDocument(ctx, "note", Deletion{
+				At: now, Source: model.SourcePrivateAPI, Reason: DeletionReasonExplicitFeed,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := st.DB().ExecContext(ctx, "UPDATE notes SET "+change+" WHERE id = 'note'"); err != nil {
+				t.Fatal(err)
+			}
+			before, _, err := st.GetNote(ctx, "note")
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := "fallback"
+			if err := st.UpsertNote(ctx, model.Note{
+				ID: "note", Type: "meeting", Source: model.SourceDesktopCache,
+				CreatedAt: now, UpdatedAt: now.Add(time.Hour), LastSeenAt: now.Add(time.Hour), NotesPlain: &body,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			after, _, err := st.GetNote(ctx, "note")
+			if err != nil || !reflect.DeepEqual(before, after) {
+				t.Fatalf("non-stub lost precedence: %+v err=%v", after, err)
+			}
+		})
+	}
+}
 
 func TestNotePriorityAndFreshness(t *testing.T) {
 	for _, tc := range []struct {

--- a/internal/store/note_priority_test.go
+++ b/internal/store/note_priority_test.go
@@ -1,0 +1,82 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openclaw/graincrawl/internal/model"
+)
+
+func TestNotePriorityAndFreshness(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		from, to           model.Source
+		older, keep, clear bool
+	}{
+		{"older cache", model.SourcePrivateAPI, model.SourceDesktopCache, true, true, true},
+		{"newer cache", model.SourcePrivateAPI, model.SourceDesktopCache, false, true, true},
+		{"encrypted cache", model.SourcePrivateAPI, model.SourceEncryptedJSON, false, true, false},
+		{"older API", model.SourcePrivateAPI, model.SourcePrivateAPI, true, true, false},
+		{"API clears", model.SourcePrivateAPI, model.SourcePrivateAPI, false, false, true},
+		{"cache clears", model.SourceDesktopCache, model.SourceDesktopCache, false, false, true},
+		{"equivalent cache", model.SourceDesktopCache, model.SourceEncryptedJSON, true, true, false},
+		{"public source freshness", model.SourcePublicAPI, model.SourcePublicAPI, true, true, false},
+		{"public cache compatibility", model.SourcePublicAPI, model.SourceDesktopCache, true, false, false},
+		{"API promotion", model.SourceDesktopCache, model.SourcePrivateAPI, true, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st, err := Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer st.Close()
+			now := time.Date(2026, 9, 8, 12, 0, 0, 500, time.UTC)
+			body, summary := "original", "summary"
+			original := model.Note{ID: "note", Type: "meeting", CreatedAt: now, UpdatedAt: now, LastSeenAt: now, NotesPlain: &body, SummaryText: &summary, Source: tc.from}
+			if err := st.UpsertNote(ctx, original); err != nil {
+				t.Fatal(err)
+			}
+			incoming := original
+			incoming.Source = tc.to
+			incoming.UpdatedAt = now.Add(time.Second)
+			if tc.older {
+				incoming.UpdatedAt = now.Add(-500 * time.Nanosecond)
+			}
+			replacement := "replacement"
+			incoming.NotesPlain = &replacement
+			if tc.clear {
+				incoming.NotesPlain, incoming.SummaryText = nil, nil
+			}
+			deleted := now.Add(time.Hour)
+			incoming.DeletedAt, incoming.DeletionSource = &deleted, string(tc.to)
+			if err := st.UpsertNote(ctx, incoming); err != nil {
+				t.Fatal(err)
+			}
+			got, ok, err := st.GetNote(ctx, "note")
+			if err != nil || !ok {
+				t.Fatalf("read: %v %v", ok, err)
+			}
+			if tc.keep {
+				if got.Source != original.Source || !got.UpdatedAt.Equal(original.UpdatedAt) || got.NotesPlain == nil || *got.NotesPlain != body || got.SummaryText == nil || *got.SummaryText != summary {
+					t.Fatalf("canonical content regressed: %+v", got)
+				}
+			} else if got.Source != incoming.Source || !got.UpdatedAt.Equal(incoming.UpdatedAt) || (tc.clear && (got.NotesPlain != nil || got.SummaryText != nil)) {
+				t.Fatalf("authoritative update rejected: %+v", got)
+			}
+			if got.DeletedAt == nil || !got.DeletedAt.Equal(deleted) {
+				t.Fatal("lost tombstone")
+			}
+			incoming.DeletedAt = nil
+			if err := st.UpsertNote(ctx, incoming); err != nil {
+				t.Fatal(err)
+			}
+			got, _, err = st.GetNote(ctx, "note")
+			if err != nil || got.DeletedAt == nil {
+				t.Fatalf("cleared existing tombstone: %v", err)
+			}
+		})
+	}
+}

--- a/internal/store/notes.go
+++ b/internal/store/notes.go
@@ -9,7 +9,28 @@ import (
 )
 
 func (s *Store) UpsertNote(ctx context.Context, note model.Note) error {
-	_, err := s.DB().ExecContext(ctx, `
+	tx, err := s.DB().BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var source, updated string
+	err = tx.QueryRowContext(ctx, "SELECT source, updated_at FROM notes WHERE id = ?", note.ID).Scan(&source, &updated)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+	if err == nil && preserveCanonicalNote(model.Source(source), updated, note) {
+		// Content precedence must not discard independent deletion evidence.
+		if _, err := tx.ExecContext(ctx, `UPDATE notes SET
+			deleted_at=COALESCE(deleted_at, ?),
+			deletion_source=COALESCE(deletion_source, ?),
+			deletion_reason=COALESCE(deletion_reason, ?)
+			WHERE id = ?`, timePtr(note.DeletedAt), nullableString(note.DeletionSource), nullableString(note.DeletionReason), note.ID); err != nil {
+			return err
+		}
+		return tx.Commit()
+	}
+	_, err = tx.ExecContext(ctx, `
 INSERT INTO notes (
   id, title, type, status, created_at, updated_at, deleted_at, workspace_id,
   calendar_event_id, notes_plain, notes_markdown, summary_text,
@@ -38,7 +59,24 @@ ON CONFLICT(id) DO UPDATE SET
 		note.CalendarEventID, note.NotesPlain, note.NotesMarkdown, note.SummaryText,
 		note.SummaryMarkdown, string(note.Source), note.PayloadHash, note.LastSeenAt.Format(time.RFC3339Nano),
 		nullableString(note.DeletionSource), nullableString(note.DeletionReason))
-	return err
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func preserveCanonicalNote(source model.Source, updated string, incoming model.Note) bool {
+	cache := func(s model.Source) bool {
+		return s == model.SourceDesktopCache || s == model.SourceEncryptedJSON
+	}
+	if source == model.SourcePrivateAPI && cache(incoming.Source) {
+		return true
+	}
+	if source == incoming.Source || (cache(source) && cache(incoming.Source)) {
+		previous, err := time.Parse(time.RFC3339Nano, updated)
+		return err == nil && incoming.UpdatedAt.Before(previous)
+	}
+	return false
 }
 
 func (s *Store) ListNotes(ctx context.Context, limit int) ([]model.Note, error) {

--- a/internal/store/notes.go
+++ b/internal/store/notes.go
@@ -15,11 +15,21 @@ func (s *Store) UpsertNote(ctx context.Context, note model.Note) error {
 	}
 	defer tx.Rollback()
 	var source, updated string
-	err = tx.QueryRowContext(ctx, "SELECT source, updated_at FROM notes WHERE id = ?", note.ID).Scan(&source, &updated)
+	var deletionOnly bool
+	// Only TombstoneDocument's empty placeholder lacks all content metadata and
+	// uses the deletion observation for every timestamp. It is not source content.
+	err = tx.QueryRowContext(ctx, `SELECT source, updated_at, COALESCE(
+		type = 'unknown' AND deleted_at IS NOT NULL
+		AND title IS NULL AND status IS NULL AND workspace_id IS NULL
+		AND calendar_event_id IS NULL AND notes_plain IS NULL AND notes_markdown IS NULL
+		AND summary_text IS NULL AND summary_markdown IS NULL AND payload_hash IS NULL
+		AND created_at = deleted_at AND updated_at = deleted_at AND last_seen_at = deleted_at
+		AND source = deletion_source AND deletion_reason <> '', 0)
+		FROM notes WHERE id = ?`, note.ID).Scan(&source, &updated, &deletionOnly)
 	if err != nil && err != sql.ErrNoRows {
 		return err
 	}
-	if err == nil && preserveCanonicalNote(model.Source(source), updated, note) {
+	if err == nil && !deletionOnly && preserveCanonicalNote(model.Source(source), updated, note) {
 		// Content precedence must not discard independent deletion evidence.
 		if _, err := tx.ExecContext(ctx, `UPDATE notes SET
 			deleted_at=COALESCE(deleted_at, ?),

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -504,6 +504,14 @@ func TestRunFallsBackToDesktopCacheWhenPrivateAPICredentialsAreMissing(t *testin
 		t.Fatal(err)
 	}
 	defer st.Close()
+	now := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
+	body, summary := "API body", "API summary"
+	if err := st.UpsertNote(ctx, model.Note{
+		ID: "doc1", Type: "meeting", CreatedAt: now, UpdatedAt: now,
+		LastSeenAt: now, Source: model.SourcePrivateAPI, NotesPlain: &body, SummaryText: &summary,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	cfg := config.Config{
 		Granola: config.GranolaConfig{
 			ProfilePath:       profile,
@@ -519,6 +527,14 @@ func TestRunFallsBackToDesktopCacheWhenPrivateAPICredentialsAreMissing(t *testin
 	}
 	if result.Source != model.SourceDesktopCache || result.Notes != 1 {
 		t.Fatalf("expected implicit sync to import the desktop cache, got %#v", result)
+	}
+	note, ok, err := st.GetNote(ctx, "doc1")
+	if err != nil || !ok || note.Source != model.SourcePrivateAPI || !note.UpdatedAt.Equal(now) || note.NotesPlain == nil || *note.NotesPlain != body || note.SummaryText == nil || *note.SummaryText != summary {
+		t.Fatalf("fallback replaced canonical API data: %+v %v", note, err)
+	}
+	var retained int
+	if err := st.DB().QueryRowContext(ctx, "SELECT count(*) FROM source_objects WHERE source = 'desktop-cache' AND source_id = 'doc1'").Scan(&retained); err != nil || retained != 1 {
+		t.Fatalf("fallback observation missing: count=%d err=%v", retained, err)
 	}
 	if _, err := Run(ctx, cfg, st, Options{Source: model.SourcePrivateAPI}); !errors.Is(err, ErrPrivateAPITokenNotFound) {
 		t.Fatalf("explicit private-api should report missing authentication, got %v", err)


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes cases where Desktop fallback could replace more authoritative notes, same-title Markdown exports could overwrite each other, and archived summaries were omitted from Markdown or human-readable note output.

## Why This Change Was Made

- Preserve source priority and freshness when notes are updated, without losing deletion evidence.
- Let demonstrably deletion-only placeholders acquire archived content while retaining note and child tombstones; populated notes keep their existing precedence rules.
- Add a stable note-ID digest to Markdown filenames so distinct notes retain distinct outputs.
- Include archived summaries in Markdown exports and human-readable `note get` output.

The dependency remains the published `crawlkit v0.14.9`. No schema, dependency pin, provider-write or snapshot wire-format change is included.

## User Impact

Desktop fallback no longer replaces authoritative API note content. Distinct notes with the same title export separately and retain stable names on subsequent exports. Summaries are available in the existing output surfaces.

A delete-first archive can retain content discovered later without making the deleted note or its children live again. Content source and deletion provenance remain separate.

Markdown filenames intentionally gain an identity suffix. Existing export files are not removed or renamed automatically.

## Evidence

- Exact reviewed source: `bfdc666a568725575083e68692980a2bd033ed4c`, with a verified SSH-signed repair commit.
- Published-pin full `go test`, `go build`, `go vet`, module verification, and tidy-with-no-module-diff gates previously passed at `7f84fd5158c70967671ebf7cf71e677bcf81750f` with Go 1.27.1 and `GOWORK=off`.
- The new hydration regression fails on that prior head for Desktop cache, encrypted JSON, and older private API content. All three pass after this repair, preserving every note/child tombstone and checking that normal precedence resumes once content exists.
- Repair validation: `go test -mod=readonly -p 1 -count=1 -timeout=120s ./internal/store ./internal/syncer` and vet on those packages passed (66 tests/subtests, no skips).
- Independent structured source review completed. Its sole claimed public-API precedence regression was rejected after an isolated before/after probe passed on both versions: that transition was already allowed, and deletion provenance remains intact. No source-policy change was made.
- Regressions cover source priority/freshness, retained deletion evidence, colliding titles, stable filenames, and Markdown/human-readable summaries.
- Validation used bounded resources, temporary homes/stores and synthetic fixtures without real providers or native credentials. The live public API test remained skipped.
- Hosted checks for the updated draft are pending. No unchanged full local suites were rerun for this repair; native/live-provider and consumer race validation are not claimed.
