### PR TITLE
chore: update CrawlKit to v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update CrawlKit to v0.15.0 while retaining the Go 1.27.1 minimum.
 - Allow deletion-only placeholders to acquire archived content while retaining note and child tombstones and normal precedence for populated notes.
 - Preserve private API notes during desktop-cache fallback and reject older updates from the same source without losing deletion evidence.
 - Include a stable note-ID digest in Markdown filenames to prevent same-title exports overwriting one another; existing export files are not removed.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openclaw/graincrawl
 go 1.27.1
 
 require (
-	github.com/openclaw/crawlkit v0.14.9
+	github.com/openclaw/crawlkit v0.15.0
 	github.com/pelletier/go-toml/v2 v2.4.3
 	modernc.org/sqlite v1.58.0
 )

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.9 h1:nlLxcBvwtgVw5WehmjQCrRyfIYrDyQbJ3zPyKhUeta0=
-github.com/openclaw/crawlkit v0.14.9/go.mod h1:jGtyzzrIcBPzj0fTiP2I+/LcfTMsfT/o9Zx8jh0HMDc=
+github.com/openclaw/crawlkit v0.15.0 h1:KAmdew2UQPZm/gOfqiLw/WhhDY7Y2UZj0EcgQ5s7dl4=
+github.com/openclaw/crawlkit v0.15.0/go.mod h1:JhEsXnoxozd2qp1p4Dw8ZhKzQoYm3WbrlvO0ILVx8cs=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Updates Graincrawl to the published CrawlKit v0.15.0 after the archive-consistency fixes landed.

## Why This Change Was Made

The complete selected-module change is CrawlKit v0.14.9 to v0.15.0. This PR changes only the module pin, its checksums, and the changelog. Go 1.27.1 and the selected SQLite v1.58.0/libc v1.75.6 pair remain unchanged. There are no module replacements, source-policy changes, schema changes, or release changes.

## User Impact

Graincrawl consumes the published shared archive fixes while preserving its current source handling and Go minimum. Legacy export-directory migration remains a separate follow-up.

## Evidence

- Signed pin commit: `0f903191c63b6c4def21bdb8f9260ac57536755d`, based on landed source `024620a826eed4c74a64abc05ae745e05a9502bc`.
- Go 1.27.1, `GOWORK=off`: tidy-no-diff, module verification, all-package build and vet passed.
- The reviewed private test-only overlay passed both actual Grain callback contracts, with 14 passing test/subtest results. It uses the published module, not a replacement: legacy unsafe integers bind as `int64`, ordinary numeric fields remain `float64`, and unsafe v1 exports refuse without replacing the prior pack.
- Built-binary `--help`, `--version`, `metadata --json`, `status --json`, and `tui --json` passed output, exit, and temporary-file inventory checks.
- Pinned govulncheck v1.7.0 completed against a fresh frozen advisory database: 170 OSV records retained, zero called/imported/module findings. Config, selected graph, complete JSON, and normal completion were checked. Scope is Linux AMD64, CGO disabled, Go 1.27.1, default tags; no native or universal clearance is claimed.
- Focused review passed. Validation used isolated temporary homes/stores, read-only source/dependencies, denied network, and bounded resources.
- Final-head [hosted CI](https://github.com/openclaw/graincrawl/actions/runs/34293197041) passed the full test suite, build, vet, dependencies, and snapshot checks; CodeQL and secret scanning also passed. The unchanged workflow has no dedicated race or coverage step, and no such new-pin result is claimed. This stays a draft for bounded final review; no app release is requested.
